### PR TITLE
Hoyyeva/context size fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ollama",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ollama",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "ollama": "^0.6.3"

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -360,10 +360,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function modelFamily(model: OllamaTagsModel, show: OllamaShowResponse | undefined): string {
-  return nonEmptyString(model.details?.family)
-    ?? nonEmptyString(show?.details?.family)
-    ?? nonEmptyString(model.name.split(':')[0])
-    ?? model.name;
+  const family = model.details?.family ?? show?.details?.family;
+  return typeof family === 'string' && family.length > 0
+    ? family
+    : model.name.split(':')[0] || model.name;
 }
 
 function modelTokenLimits(model: OllamaTagsModel, show: OllamaShowResponse | undefined) {
@@ -499,10 +499,6 @@ function mergedCapabilities(...sources: Array<readonly string[] | undefined>): s
     }
   }
   return [...capabilities];
-}
-
-function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function isAuthError(error: unknown): error is OllamaAPIError {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -33,7 +33,6 @@ const defaultCharsPerToken = 4;
 export interface OllamaTagsModel {
   name: string;
   model?: string;
-  remote_model?: string;
   remote_host?: string;
   modified_at?: Date;
   size?: number;
@@ -261,16 +260,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
   ): OllamaLanguageModel {
     const capabilities = mergedCapabilities(model.capabilities, show?.capabilities);
     const name = model.name;
-    const explicitMaxInputTokens = tokenLimit(model, show, 'input');
-    const contextWindow = contextWindowLimit(model, show)
-      ?? (explicitMaxInputTokens === undefined ? fallbackContextWindow : undefined);
-    const explicitMaxOutputTokens = tokenLimit(model, show, 'output');
-    const maxOutputTokens = contextWindow !== undefined
-      ? sharedOutputTokenLimit(contextWindow, explicitMaxOutputTokens)
-      : explicitMaxOutputTokens ?? defaultMaxOutputTokens;
-    const maxInputTokens = contextWindow !== undefined
-      ? contextWindow - maxOutputTokens
-      : explicitMaxInputTokens ?? fallbackContextWindow;
+    const { maxInputTokens, maxOutputTokens } = modelTokenLimits(model, show);
 
     return {
       id: name,
@@ -341,12 +331,12 @@ function shouldHydrateModel(model: OllamaTagsModel): boolean {
     return true;
   }
   return model.capabilities === undefined
-    || contextWindowLimit(model, undefined) === undefined
-    && tokenLimit(model, undefined, 'input') === undefined;
+    || (sharedContextWindow(model, undefined) === undefined
+      && explicitTokenLimit(model, undefined, 'input') === undefined);
 }
 
 function isRemoteModel(model: OllamaTagsModel): boolean {
-  return typeof model.remote_host === 'string' && model.remote_host.length > 0 || isCloudModel(model.name);
+  return typeof model.remote_host === 'string' && model.remote_host.length > 0;
 }
 
 function getConfiguredHeaders(
@@ -376,7 +366,28 @@ function modelFamily(model: OllamaTagsModel, show: OllamaShowResponse | undefine
     ?? model.name;
 }
 
-function tokenLimit(
+function modelTokenLimits(model: OllamaTagsModel, show: OllamaShowResponse | undefined) {
+  const explicitMaxInputTokens = explicitTokenLimit(model, show, 'input');
+  const explicitMaxOutputTokens = explicitTokenLimit(model, show, 'output');
+  const contextWindow = sharedContextWindow(model, show)
+    ?? (explicitMaxInputTokens === undefined ? fallbackContextWindow : undefined);
+
+  if (contextWindow === undefined) {
+    return {
+      maxInputTokens: explicitMaxInputTokens ?? fallbackContextWindow,
+      maxOutputTokens: explicitMaxOutputTokens ?? defaultMaxOutputTokens
+    };
+  }
+
+  // VS Code displays input + output; Ollama reports one shared context window.
+  const maxOutputTokens = outputTokenLimit(contextWindow, explicitMaxOutputTokens);
+  return {
+    maxInputTokens: contextWindow - maxOutputTokens,
+    maxOutputTokens
+  };
+}
+
+function explicitTokenLimit(
   model: OllamaTagsModel,
   show: OllamaShowResponse | undefined,
   kind: 'input' | 'output'
@@ -398,7 +409,7 @@ function tokenLimit(
   return undefined;
 }
 
-function contextWindowLimit(model: OllamaTagsModel, show: OllamaShowResponse | undefined): number | undefined {
+function sharedContextWindow(model: OllamaTagsModel, show: OllamaShowResponse | undefined): number | undefined {
   const keys = ['max_context_length', 'context_length'];
 
   for (const value of [
@@ -418,7 +429,7 @@ function contextWindowLimit(model: OllamaTagsModel, show: OllamaShowResponse | u
   return undefined;
 }
 
-function sharedOutputTokenLimit(contextWindow: number, configuredOutputLimit: number | undefined): number {
+function outputTokenLimit(contextWindow: number, configuredOutputLimit: number | undefined): number {
   if (contextWindow <= 1) {
     return 0;
   }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -6,6 +6,7 @@ import {
   ChatResponse,
   Message,
   ModelResponse,
+  ShowRequest,
   ShowResponse,
   Tool,
   ToolCall
@@ -25,12 +26,15 @@ interface OllamaLanguageModel extends vscode.LanguageModelChatInformation {
 }
 
 const defaultOllamaURL = 'http://127.0.0.1:11434';
-const fallbackMaxInputTokens = 32768;
+const fallbackContextWindow = 32768;
+const defaultMaxOutputTokens = 4096;
 const defaultCharsPerToken = 4;
 
 export interface OllamaTagsModel {
   name: string;
   model?: string;
+  remote_model?: string;
+  remote_host?: string;
   modified_at?: Date;
   size?: number;
   digest?: string;
@@ -143,7 +147,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       } catch (error) {
         throw this.userFacingError(error);
       }
-      const hydratedModels = await hydrateModels(ollama, models, configuration.models);
+      const hydratedModels = await hydrateModels(ollama, models);
 
       const versionSuffix = version ? ` with Ollama ${version}` : '';
       this.output?.appendLine(`Providing ${models.length} Ollama model(s) from ${configuration.url}${versionSuffix}.`);
@@ -255,9 +259,18 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     show: OllamaShowResponse | undefined,
     configuration: OllamaProviderConfiguration
   ): OllamaLanguageModel {
-    const capabilities = model.capabilities ?? show?.capabilities ?? [];
+    const capabilities = mergedCapabilities(model.capabilities, show?.capabilities);
     const name = model.name;
-    const maxInputTokens = tokenLimit(model, show, 'input') ?? fallbackMaxInputTokens;
+    const explicitMaxInputTokens = tokenLimit(model, show, 'input');
+    const contextWindow = contextWindowLimit(model, show)
+      ?? (explicitMaxInputTokens === undefined ? fallbackContextWindow : undefined);
+    const explicitMaxOutputTokens = tokenLimit(model, show, 'output');
+    const maxOutputTokens = contextWindow !== undefined
+      ? sharedOutputTokenLimit(contextWindow, explicitMaxOutputTokens)
+      : explicitMaxOutputTokens ?? defaultMaxOutputTokens;
+    const maxInputTokens = contextWindow !== undefined
+      ? contextWindow - maxOutputTokens
+      : explicitMaxInputTokens ?? fallbackContextWindow;
 
     return {
       id: name,
@@ -266,7 +279,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       tooltip: name,
       version: '1.0',
       maxInputTokens,
-      maxOutputTokens: tokenLimit(model, show, 'output') ?? maxInputTokens,
+      maxOutputTokens,
       capabilities: {
         toolCalling: hasCapability(capabilities, 'tools', 'tool'),
         imageInput: hasCapability(capabilities, 'vision', 'image')
@@ -304,28 +317,36 @@ function selectConfiguredModels(
 
 async function hydrateModels(
   ollama: Ollama,
-  models: readonly OllamaTagsModel[],
-  configuredModels: readonly string[]
+  models: readonly OllamaTagsModel[]
 ): Promise<Array<{ model: OllamaTagsModel; show?: OllamaShowResponse }>> {
-  const configured = new Set(configuredModels);
-  const hydrated: Array<{ model: OllamaTagsModel; show?: OllamaShowResponse }> = [];
-  for (const model of models) {
-    hydrated.push({
-      model,
-      show: configured.has(model.name) && isFallbackModel(model)
-        ? await ollama.show({ model: model.name }).then(show => show as OllamaShowResponse).catch(() => undefined)
-        : undefined
-    });
-  }
-  return hydrated;
+  return Promise.all(models.map(async model => ({
+    model,
+    show: shouldHydrateModel(model) ? await showModel(ollama, model.name) : undefined
+  })));
 }
 
 function isOllamaTagsModel(model: unknown): model is OllamaTagsModel {
   return isRecord(model) && typeof model.name === 'string' && model.name.length > 0;
 }
 
-function isFallbackModel(model: OllamaTagsModel): boolean {
-  return model.details === undefined && model.capabilities === undefined;
+async function showModel(ollama: Ollama, model: string): Promise<OllamaShowResponse | undefined> {
+  const request: ShowRequest & { verbose?: boolean } = { model, verbose: false };
+  return ollama.show(request)
+    .then(show => show as OllamaShowResponse)
+    .catch(() => undefined);
+}
+
+function shouldHydrateModel(model: OllamaTagsModel): boolean {
+  if (!isRemoteModel(model)) {
+    return true;
+  }
+  return model.capabilities === undefined
+    || contextWindowLimit(model, undefined) === undefined
+    && tokenLimit(model, undefined, 'input') === undefined;
+}
+
+function isRemoteModel(model: OllamaTagsModel): boolean {
+  return typeof model.remote_host === 'string' && model.remote_host.length > 0 || isCloudModel(model.name);
 }
 
 function getConfiguredHeaders(
@@ -349,10 +370,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function modelFamily(model: OllamaTagsModel, show: OllamaShowResponse | undefined): string {
-  const family = model.details?.family ?? show?.details?.family;
-  return typeof family === 'string' && family.length > 0
-    ? family
-    : model.name.split(':')[0] || model.name;
+  return nonEmptyString(model.details?.family)
+    ?? nonEmptyString(show?.details?.family)
+    ?? nonEmptyString(model.name.split(':')[0])
+    ?? model.name;
 }
 
 function tokenLimit(
@@ -360,9 +381,7 @@ function tokenLimit(
   show: OllamaShowResponse | undefined,
   kind: 'input' | 'output'
 ): number | undefined {
-  const keys = kind === 'input'
-    ? ['max_input_tokens', 'max_context_length', 'context_length']
-    : ['max_output_tokens'];
+  const keys = kind === 'input' ? ['max_input_tokens'] : ['max_output_tokens'];
 
   for (const value of [
     numericField(model, keys),
@@ -377,6 +396,56 @@ function tokenLimit(
     }
   }
   return undefined;
+}
+
+function contextWindowLimit(model: OllamaTagsModel, show: OllamaShowResponse | undefined): number | undefined {
+  const keys = ['max_context_length', 'context_length'];
+
+  for (const value of [
+    numericParameterValue(show?.parameters, 'num_ctx'),
+    numericParameterValue(show?.modelfile, 'num_ctx'),
+    numericField(model, keys),
+    numericField(show, keys),
+    numericField(model.details, keys),
+    numericField(show?.details, keys),
+    numericModelInfoValue(model.model_info, keys),
+    numericModelInfoValue(show?.model_info, keys)
+  ]) {
+    if (value !== undefined && value > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function sharedOutputTokenLimit(contextWindow: number, configuredOutputLimit: number | undefined): number {
+  if (contextWindow <= 1) {
+    return 0;
+  }
+
+  return Math.min(
+    configuredOutputLimit ?? defaultMaxOutputTokens,
+    contextWindow - 1
+  );
+}
+
+function numericParameterValue(text: string | undefined, name: string): number | undefined {
+  if (!text) {
+    return undefined;
+  }
+
+  const pattern = new RegExp(`^\\s*(?:PARAMETER\\s+)?${escapeRegExp(name)}\\s+(-?\\d+)\\b`, 'im');
+  const match = text.match(pattern);
+  if (!match) {
+    return undefined;
+  }
+
+  const value = Number(match[1]);
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function numericField(value: unknown, keys: readonly string[]): number | undefined {
@@ -409,6 +478,20 @@ function numericModelInfoValue(modelInfo: ModelInfo | undefined, keys: readonly 
 function hasCapability(capabilities: readonly string[], ...expected: string[]): boolean {
   const values = new Set(capabilities.map(capability => capability.toLowerCase()));
   return expected.some(capability => values.has(capability));
+}
+
+function mergedCapabilities(...sources: Array<readonly string[] | undefined>): string[] {
+  const capabilities = new Set<string>();
+  for (const source of sources) {
+    for (const capability of source ?? []) {
+      capabilities.add(capability);
+    }
+  }
+  return [...capabilities];
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function isAuthError(error: unknown): error is OllamaAPIError {


### PR DESCRIPTION
## Summary

Fix Ollama model context window reporting in VS Code.

VS Code displays a model’s context as `maxInputTokens + maxOutputTokens`, while Ollama reports context length as a shared window. Previously, shared Ollama context values like `262144` could be assigned to both input and output, causing VS Code to display doubled values like `524K`.

This change:
- treats Ollama `context_length`, `max_context_length`, and `num_ctx` as a shared context window
- splits that shared window into VS Code `maxInputTokens` and `maxOutputTokens`
- reads local model `num_ctx` from `/api/show` parameters / Modelfile
- uses `/api/tags` context metadata for remote models when available
- keeps explicit `max_input_tokens` / `max_output_tokens` handling separate from shared context window handling

## Testing

- `npm run compile`
- Manual sandbox covering:
  - local model with `PARAMETER num_ctx 162144`
  - `/api/tags` model with `context_length: 262144`
  - remote cloud model with `context_length: 1000000`