### PR TITLE
handle text-form tool calls from ollama models

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -3,6 +3,7 @@ import { OllamaChatMessage, OllamaTool } from './provider';
 
 export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequestMessage[]): OllamaChatMessage[] {
   const converted: OllamaChatMessage[] = [];
+  const toolNamesByCallId = new Map<string, string>();
 
   for (const message of messages) {
     const text: string[] = [];
@@ -20,6 +21,7 @@ export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequ
           text.push(new TextDecoder().decode(part.data));
         }
       } else if (part instanceof vscode.LanguageModelToolCallPart) {
+        toolNamesByCallId.set(part.callId, part.name);
         toolCalls.push({
           id: part.callId,
           function: {
@@ -31,7 +33,7 @@ export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequ
         toolResults.push({
           role: 'tool',
           content: toolResultContent(part),
-          tool_call_id: part.callId
+          tool_name: toolNamesByCallId.get(part.callId)
         });
       }
     }
@@ -76,13 +78,13 @@ function roleToOllama(role: vscode.LanguageModelChatMessageRole): string {
 }
 
 function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
-  return part.content.map(item => {
+  return part.content.flatMap(item => {
     if (item instanceof vscode.LanguageModelTextPart) {
-      return item.value;
+      return [item.value];
     }
     if (item instanceof vscode.LanguageModelDataPart && item.mimeType.startsWith('text/')) {
-      return new TextDecoder().decode(item.data);
+      return [new TextDecoder().decode(item.data)];
     }
-    return JSON.stringify(item);
+    return [];
   }).join('\n');
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -59,7 +59,7 @@ type ModelInfo = Record<string, unknown> | Map<string, unknown>;
 export interface OllamaChatMessage extends Message {
   images?: string[];
   tool_calls?: OllamaToolCall[];
-  tool_call_id?: string;
+  tool_name?: string;
 }
 
 export interface OllamaTool extends Tool {
@@ -175,9 +175,13 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
 
     try {
       let promptTokenCount: number | undefined;
+      const contentBuffer: string[] = [];
+      let bufferingContent = tools.length > 0;
+      let reportedToolCall = false;
+      const requestMessages = toOllamaMessages(messages);
       const stream = await ollama.chat({
         model: model.model,
-        messages: toOllamaMessages(messages),
+        messages: requestMessages,
         stream: true,
         tools: tools.length > 0 ? tools : undefined,
         options: options.modelOptions ? { ...options.modelOptions } : undefined
@@ -193,15 +197,32 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
 
         const content = response.message?.content;
         if (content) {
-          progress.report(new vscode.LanguageModelTextPart(content));
+          if (bufferingContent && !reportedToolCall) {
+            contentBuffer.push(content);
+            if (!couldBeTextToolCall(contentBuffer.join(''))) {
+              progress.report(new vscode.LanguageModelTextPart(contentBuffer.join('')));
+              contentBuffer.length = 0;
+              bufferingContent = false;
+            }
+          } else {
+            progress.report(new vscode.LanguageModelTextPart(content));
+          }
         }
 
         for (const toolCall of response.message?.tool_calls ?? []) {
-          progress.report(new vscode.LanguageModelToolCallPart(
-            toolCall.id ?? randomUUID(),
-            toolCall.function.name,
-            toolCall.function.arguments
-          ));
+          reportedToolCall = true;
+          progress.report(toolCallPart(toolCall));
+        }
+      }
+      if (contentBuffer.length > 0) {
+        const content = contentBuffer.join('');
+        const toolCalls = reportedToolCall ? undefined : parseTextToolCalls(content, tools);
+        if (toolCalls) {
+          for (const toolCall of toolCalls) {
+            progress.report(toolCallPart(toolCall));
+          }
+        } else {
+          progress.report(new vscode.LanguageModelTextPart(content));
         }
       }
       if (promptTokenCount !== undefined) {
@@ -357,6 +378,90 @@ function getConfiguredHeaders(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toolCallPart(toolCall: OllamaToolCall): vscode.LanguageModelToolCallPart {
+  return new vscode.LanguageModelToolCallPart(
+    toolCall.id ?? randomUUID(),
+    toolCall.function.name,
+    toolCall.function.arguments
+  );
+}
+
+function parseTextToolCalls(content: string, tools: readonly OllamaTool[]): OllamaToolCall[] | undefined {
+  const parsed = parseJSON(stripCodeFence(content));
+  if (parsed === undefined) {
+    return undefined;
+  }
+
+  const toolNames = new Set(tools.map(tool => tool.function.name).filter((name): name is string => typeof name === 'string'));
+  const candidates = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.tool_calls)
+      ? parsed.tool_calls
+      : [parsed];
+  const toolCalls = candidates
+    .map(candidate => textToolCall(candidate, toolNames))
+    .filter((toolCall): toolCall is OllamaToolCall => toolCall !== undefined);
+
+  return toolCalls.length === candidates.length && toolCalls.length > 0 ? toolCalls : undefined;
+}
+
+function textToolCall(value: unknown, toolNames: ReadonlySet<string>): OllamaToolCall | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const id = typeof value.id === 'string' ? value.id : undefined;
+  const source = isRecord(value.function) ? value.function : value;
+  const name = typeof source.name === 'string' ? source.name : undefined;
+  const input = parseToolArguments(source.arguments);
+
+  if (!name || !toolNames.has(name) || input === undefined) {
+    return undefined;
+  }
+
+  return {
+    id,
+    function: {
+      name,
+      arguments: input
+    }
+  };
+}
+
+function parseToolArguments(value: unknown): Record<string, unknown> | undefined {
+  if (isRecord(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = parseJSON(value);
+    return isRecord(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function parseJSON(value: string): Record<string, unknown> | unknown[] | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) || Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function stripCodeFence(value: string): string {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return match ? match[1].trim() : trimmed;
+}
+
+function couldBeTextToolCall(value: string): boolean {
+  const trimmed = value.trimStart().toLowerCase();
+  if (trimmed.length === 0) {
+    return true;
+  }
+  return ['{', '[', '```'].some(prefix => prefix.startsWith(trimmed) || trimmed.startsWith(prefix));
 }
 
 function modelFamily(model: OllamaTagsModel, show: OllamaShowResponse | undefined): string {


### PR DESCRIPTION
## Summary

Fix tool-call handling for models that return tool-call JSON as plain text.

Some Ollama models, such as `qwen2.5-coder:7b`, may respond to VS Code Agent tool requests with JSON in `message.content` instead of structured `message.tool_calls`. VS Code treats that as normal assistant text, so Copilot prints the JSON instead of executing the tool.

This change adds a compatibility fallback that detects JSON-only tool-call responses when tools were provided, validates the tool name against the tools VS Code offered, and converts the response into a `LanguageModelToolCallPart`.

Also fixes tool result conversion back to Ollama by:
- sending `tool_name` instead of `tool_call_id`
- omitting non-text/internal tool result parts such as VS Code cache-control metadata

## Testing

- `npm run compile`
- `git diff --check`
- Manually installed local VSIX and tested with `qwen2.5-coder:7b`
- Verified plain JSON tool calls are converted into real VS Code tool calls
- Verified internal `cache_control` metadata is no longer sent back in tool result content

## Notes

This fixes the extension-side tool-call transport issue. Models may still produce invalid tool arguments or choose poor/repetitive tools, but those calls now reach VS Code as actual tool calls instead of being printed as chat text.

resolving #12 