### PR TITLE
bump version to 0.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ollama",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ollama",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "ollama": "^0.6.3"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Ollama",
   "description": "Ollama language model provider for VS Code.",
   "publisher": "Ollama",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "icon": "images/icon.png",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the extension version from `0.0.3` to `0.0.4`
- keep `package.json` and `package-lock.json` in sync

This prepares the Marketplace release for the changes merged in #21. It does not publish the extension or create a tag or GitHub release.

## Validation

- `npm run compile`
- `node --test test/recommendations.test.js` (10 passing)
