### PR TITLE
fix: exactOptionalPropertyTypes violations

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -37,12 +37,17 @@ export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequ
     }
 
     if (text.length > 0 || images.length > 0 || toolCalls.length > 0) {
-      converted.push({
+      const convertedMessage: OllamaChatMessage = {
         role: roleToOllama(message.role),
-        content: text.join('\n'),
-        images: images.length > 0 ? images : undefined,
-        tool_calls: toolCalls.length > 0 ? toolCalls : undefined
-      });
+        content: text.join('\n')
+      };
+      if (images.length > 0) {
+        convertedMessage.images = images;
+      }
+      if (toolCalls.length > 0) {
+        convertedMessage.tool_calls = toolCalls;
+      }
+      converted.push(convertedMessage);
     }
 
     converted.push(...toolResults);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -359,7 +359,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     const name = model.name;
     const { maxInputTokens, maxOutputTokens } = modelTokenLimits(model, show);
 
-    return {
+    const languageModel: OllamaLanguageModel = {
       id: name,
       name,
       family: modelFamily(model, show),
@@ -373,9 +373,12 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       },
       model: name,
       url: configuration.url,
-      headers: configuration.headers,
-      recommendedReplacement: replacement
+      headers: configuration.headers
     };
+    if (replacement !== undefined) {
+      languageModel.recommendedReplacement = replacement;
+    }
+    return languageModel;
   }
 }
 
@@ -491,10 +494,10 @@ async function hydrateModels(
   ollama: Ollama,
   models: readonly OllamaTagsModel[]
 ): Promise<Array<{ model: OllamaTagsModel; show?: OllamaShowResponse }>> {
-  return Promise.all(models.map(async model => ({
-    model,
-    show: shouldHydrateModel(model) ? await showModel(ollama, model.name) : undefined
-  })));
+  return Promise.all(models.map(async model => {
+    const show = shouldHydrateModel(model) ? await showModel(ollama, model.name) : undefined;
+    return show === undefined ? { model } : { model, show };
+  }));
 }
 
 function isOllamaTagsModel(model: unknown): model is OllamaTagsModel {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "out",
     "rootDir": "src",
     "strict": true,
+    "types": ["node"],
     "esModuleInterop": true,
     "sourceMap": true,
     "skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "out",
     "rootDir": "src",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "types": ["node"],
     "esModuleInterop": true,
     "sourceMap": true,


### PR DESCRIPTION
## Included

Type-safety fix only — makes the project compile clean under `--exactOptionalPropertyTypes`, not just `--strict`:

- `convert.ts`: build the message object incrementally and only set `images` / `tool_calls` keys when non-empty, instead of assigning `undefined` to them.
- `provider.ts`: `toLanguageModel` only sets `recommendedReplacement` when defined instead of assigning `undefined`; `hydrateModels` omits the `show` key entirely when there's nothing to hydrate.
- `tsconfig.json`: add `"types": ["node"]` so Node globals (`Buffer`, `crypto`) resolve consistently between the CLI and editor TS server.

Verified:
```
npx tsc -p ./ --noEmit --strict --exactOptionalPropertyTypes   # 0 errors
```

## Not included

This originally also included a fallback for tool calls on models without native Ollama tool-calling support. Per @ParthSareen's feedback, that approach isn't something the team wants to maintain long-term — dropped entirely from this PR, out of scope here.