### PR TITLE
src: Filter cache control metadata from tool results

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
+    "test": "npm run compile && node --test",
     "vscode:prepublish": "npm run compile",
     "watch": "tsc -watch -p ./"
   },

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -76,13 +76,24 @@ function roleToOllama(role: vscode.LanguageModelChatMessageRole): string {
 }
 
 function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
-  return part.content.map(item => {
+  const content: string[] = [];
+
+  for (const item of part.content) {
     if (item instanceof vscode.LanguageModelTextPart) {
-      return item.value;
+      content.push(item.value);
+      continue;
     }
-    if (item instanceof vscode.LanguageModelDataPart && item.mimeType.startsWith('text/')) {
-      return new TextDecoder().decode(item.data);
+    if (item instanceof vscode.LanguageModelDataPart) {
+      if (item.mimeType === 'cache_control') {
+        continue;
+      }
+      if (item.mimeType.startsWith('text/')) {
+        content.push(new TextDecoder().decode(item.data));
+        continue;
+      }
     }
-    return JSON.stringify(item);
-  }).join('\n');
+    content.push(JSON.stringify(item));
+  }
+
+  return content.join('\n');
 }

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -78,15 +78,12 @@ function roleToOllama(role: vscode.LanguageModelChatMessageRole): string {
 function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
   const content: string[] = [];
 
-  for (const item of part.content) {
+  for (const item of sanitizeToolResult(part)) {
     if (item instanceof vscode.LanguageModelTextPart) {
       content.push(item.value);
       continue;
     }
     if (item instanceof vscode.LanguageModelDataPart) {
-      if (item.mimeType === 'cache_control') {
-        continue;
-      }
       if (item.mimeType.startsWith('text/')) {
         content.push(new TextDecoder().decode(item.data));
         continue;
@@ -96,4 +93,18 @@ function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
   }
 
   return content.join('\n');
+}
+
+const providerOnlyToolResultMimeTypes: ReadonlySet<string> = new Set(['cache_control']);
+
+/**
+ * Remove provider-only metadata before tool results become model-visible text.
+ * Add future control MIME types to providerOnlyToolResultMimeTypes.
+ */
+function sanitizeToolResult(
+  part: vscode.LanguageModelToolResultPart
+): vscode.LanguageModelToolResultPart['content'] {
+  return part.content.filter(item =>
+    !(item instanceof vscode.LanguageModelDataPart && providerOnlyToolResultMimeTypes.has(item.mimeType))
+  );
 }

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -1,0 +1,92 @@
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+class LanguageModelTextPart {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class LanguageModelDataPart {
+  constructor(data, mimeType) {
+    this.mimeType = mimeType;
+    this.data = data;
+  }
+
+  toJSON() {
+    return {
+      $mid: 24,
+      mimeType: this.mimeType,
+      data: Buffer.from(this.data).toString('base64')
+    };
+  }
+}
+
+class LanguageModelToolCallPart {}
+
+class LanguageModelToolResultPart {
+  constructor(callId, content) {
+    this.callId = callId;
+    this.content = content;
+  }
+}
+
+const vscode = {
+  LanguageModelChatMessageRole: { User: 1, Assistant: 2, System: 3 },
+  LanguageModelDataPart,
+  LanguageModelTextPart,
+  LanguageModelToolCallPart,
+  LanguageModelToolResultPart
+};
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'vscode') {
+    return vscode;
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let toOllamaMessages;
+try {
+  ({ toOllamaMessages } = require('../out/convert'));
+} finally {
+  Module._load = originalLoad;
+}
+
+test('omits cache control metadata from tool results', () => {
+  const result = new LanguageModelToolResultPart('call-1', [
+    new LanguageModelTextPart('first'),
+    new LanguageModelDataPart(new TextEncoder().encode('ephemeral'), 'cache_control'),
+    new LanguageModelDataPart(new TextEncoder().encode('second'), 'text/plain')
+  ]);
+
+  assert.deepEqual(toOllamaMessages([{ role: 1, content: [result] }]), [{
+    role: 'tool',
+    content: 'first\nsecond',
+    tool_call_id: 'call-1'
+  }]);
+});
+
+test('preserves an empty tool result when it only contains cache control metadata', () => {
+  const result = new LanguageModelToolResultPart('call-2', [
+    new LanguageModelDataPart(new TextEncoder().encode('ephemeral'), 'cache_control')
+  ]);
+
+  assert.deepEqual(toOllamaMessages([{ role: 1, content: [result] }]), [{
+    role: 'tool',
+    content: '',
+    tool_call_id: 'call-2'
+  }]);
+});
+
+test('keeps the existing fallback for unknown tool result content', () => {
+  const result = new LanguageModelToolResultPart('call-3', [{ status: 'ok' }]);
+
+  assert.deepEqual(toOllamaMessages([{ role: 1, content: [result] }]), [{
+    role: 'tool',
+    content: '{"status":"ok"}',
+    tool_call_id: 'call-3'
+  }]);
+});


### PR DESCRIPTION
## Summary

Prevent VS Code's internal `cache_control` metadata from being forwarded to Ollama models as tool-result text.

The metadata was previously serialized into output resembling:

```json
{"$mid":24,"mimeType":"cache_control","data":"ZXBoZW1lcmFs"}
```
This could confuse models or cause Agent tasks to stop unexpectedly.
The fix removes the cache-control metadata while preserving the actual tool result and tool-call ID.
Testing
Added regression coverage for mixed text and cache-control results.
Confirmed cache-control-only results still preserve the tool-call ID.
Confirmed existing unknown-content handling is unchanged.
Verified the fix using an isolated VS Code extension-host test.
npm test passes all 13 tests.
The intermittent Agent stopping was not reproduced manually, but the underlying metadata leak was reproduced and confirmed fixed.

Fixes #26