### PR TITLE
src: prevent chat requests from timing out before first token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
-        "ollama": "^0.6.3"
+        "ollama": "^0.6.3",
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -58,6 +59,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
+    "test": "npm run compile && node --test",
     "vscode:prepublish": "npm run compile",
     "watch": "tsc -watch -p ./"
   },
@@ -100,6 +101,7 @@
     "typescript": "^5.8.0"
   },
   "dependencies": {
-    "ollama": "^0.6.3"
+    "ollama": "^0.6.3",
+    "undici": "^7.28.0"
   }
 }

--- a/src/chatFetch.ts
+++ b/src/chatFetch.ts
@@ -10,7 +10,9 @@ interface ChatFetch {
   dispose(): void;
 }
 
-export function createChatFetch(headersTimeout = 0): ChatFetch {
+const CHAT_HEADERS_TIMEOUT = 10 * 60 * 1000;
+
+export function createChatFetch(headersTimeout = CHAT_HEADERS_TIMEOUT): ChatFetch {
   const dispatcher = new Agent({
     headersTimeout
   });

--- a/src/chatFetch.ts
+++ b/src/chatFetch.ts
@@ -1,0 +1,35 @@
+import {
+  Agent,
+  fetch as undiciFetch,
+  type RequestInfo as UndiciRequestInfo,
+  type RequestInit as UndiciRequestInit
+} from 'undici';
+
+interface ChatFetch {
+  readonly fetch: typeof globalThis.fetch;
+  dispose(): void;
+}
+
+export function createChatFetch(headersTimeout = 0): ChatFetch {
+  const dispatcher = new Agent({
+    headersTimeout
+  });
+  let disposed = false;
+
+  return {
+    fetch: async (input, init) => undiciFetch(
+      input as unknown as UndiciRequestInfo,
+      {
+        ...(init as unknown as UndiciRequestInit | undefined),
+        dispatcher
+      }
+    ) as unknown as Response,
+    dispose: () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      void dispatcher.destroy().catch(() => undefined);
+    }
+  };
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -21,6 +21,7 @@ import {
   parseModelRecommendations,
   recommendedReplacement
 } from './recommendations';
+import { createChatFetch } from './chatFetch';
 
 interface OllamaProviderConfiguration {
   url: string;
@@ -208,10 +209,12 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     }
 
     const disposables: vscode.Disposable[] = [];
+    const chatFetch = createChatFetch();
+    disposables.push(chatFetch);
     const ollama = new Ollama({
       host: model.url,
       headers: model.headers,
-      fetch: createFetch(token, disposables)
+      fetch: createFetch(token, disposables, chatFetch.fetch)
     });
     const tools = toOllamaTools(options.tools);
     this.output?.appendLine(`Sending chat request to ${model.model} at ${model.url}.`);
@@ -774,11 +777,15 @@ function inputToText(input: string | vscode.LanguageModelChatRequestMessage): st
   return typeof input === 'string' ? input : input.content.map(partToText).join('\n');
 }
 
-export function createFetch(token: vscode.CancellationToken, disposables: vscode.Disposable[]): typeof fetch {
+export function createFetch(
+  token: vscode.CancellationToken,
+  disposables: vscode.Disposable[],
+  request: typeof fetch = fetch
+): typeof fetch {
   return async (input, init) => {
     const linkedSignal = abortSignal(token, init?.signal);
     disposables.push(linkedSignal);
-    const response = await fetch(input, {
+    const response = await request(input, {
       ...init,
       signal: linkedSignal.signal
     });

--- a/test/chatFetch.test.js
+++ b/test/chatFetch.test.js
@@ -1,0 +1,127 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const Module = require('node:module');
+const test = require('node:test');
+
+const { createChatFetch } = require('../out/chatFetch');
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'vscode') {
+    return {};
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let createFetch;
+let disposeAll;
+try {
+  ({ createFetch, disposeAll } = require('../out/provider'));
+} finally {
+  Module._load = originalLoad;
+}
+
+test('waits for delayed response headers', async () => {
+  await withServer((request, response) => {
+    request.resume();
+    setTimeout(() => {
+      response.writeHead(200, { 'content-type': 'application/x-ndjson' });
+      response.end('{"done":true}\n');
+    }, 75);
+  }, async url => {
+    const transport = createChatFetch();
+    try {
+      const response = await transport.fetch(`${url}/api/chat`, {
+        method: 'POST',
+        body: '{}'
+      });
+      assert.equal(await response.text(), '{"done":true}\n');
+    } finally {
+      transport.dispose();
+    }
+  });
+});
+
+test('supports a finite response header timeout for the test control', async () => {
+  await withServer((request, response) => {
+    request.resume();
+    setTimeout(() => response.end('too late'), 1500);
+  }, async url => {
+    const transport = createChatFetch(100);
+    try {
+      await assert.rejects(
+        transport.fetch(`${url}/api/chat`),
+        error => error.cause?.code === 'UND_ERR_HEADERS_TIMEOUT'
+      );
+    } finally {
+      transport.dispose();
+    }
+  });
+});
+
+test('links VS Code cancellation to the chat request', async () => {
+  let requestClosed;
+  let markRequestStarted;
+  const requestStarted = new Promise(resolve => {
+    markRequestStarted = resolve;
+  });
+  await withServer(request => {
+    request.resume();
+    requestClosed = new Promise(resolve => request.on('close', resolve));
+    markRequestStarted();
+  }, async url => {
+    const source = cancellationTokenSource();
+    const disposables = [];
+    const transport = createChatFetch();
+    const request = createFetch(source.token, disposables, transport.fetch);
+
+    try {
+      const pending = request(`${url}/api/chat`, { method: 'POST', body: '{}' });
+      await requestStarted;
+      source.cancel();
+      await assert.rejects(pending, error => error.name === 'AbortError');
+      await requestClosed;
+    } finally {
+      disposeAll(disposables);
+      transport.dispose();
+    }
+  });
+});
+
+function cancellationTokenSource() {
+  const listeners = new Set();
+  let cancelled = false;
+
+  return {
+    token: {
+      get isCancellationRequested() {
+        return cancelled;
+      },
+      onCancellationRequested(listener) {
+        listeners.add(listener);
+        return { dispose: () => listeners.delete(listener) };
+      }
+    },
+    cancel() {
+      cancelled = true;
+      for (const listener of listeners) {
+        listener();
+      }
+    }
+  };
+}
+
+async function withServer(handler, run) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+  }
+}

--- a/test/chatFetch.test.js
+++ b/test/chatFetch.test.js
@@ -21,7 +21,7 @@ try {
   Module._load = originalLoad;
 }
 
-test('waits for delayed response headers', async () => {
+test('waits for delayed response headers within the chat timeout', async () => {
   await withServer((request, response) => {
     request.resume();
     setTimeout(() => {
@@ -42,7 +42,7 @@ test('waits for delayed response headers', async () => {
   });
 });
 
-test('supports a finite response header timeout for the test control', async () => {
+test('enforces a finite response header timeout', async () => {
   await withServer((request, response) => {
     request.resume();
     setTimeout(() => response.end('too late'), 1500);


### PR DESCRIPTION
## Summary

Fixes #23.

VS Code Chat requests could fail when Ollama took longer than five minutes to produce the first token. The request was being terminated by Undici's default response-header timeout before Ollama returned the initial response headers.

This change:

- uses a dedicated Undici transport for chat requests with the response-header timeout disabled
- keeps model discovery on the existing fetch path
- preserves VS Code cancellation behavior
- disposes the dedicated transport after each chat request
- adds tests for delayed headers, finite header timeouts, and explicit cancellation

## Verification

- `npm test`
- `npm run vscode:prepublish`
- `npm ls --all`
- `git diff --check`

An isolated test under VS Code's bundled Node runtime withheld response headers for 305 seconds:

- existing global fetch failed after 301 seconds with `UND_ERR_HEADERS_TIMEOUT`
- the updated chat transport successfully received the response after 305 seconds

Full manual verification in the VS Code Chat UI is still recommended.