### PR TITLE
vscode: add configurable server context limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ Local models do not require sign-in. Run `ollama signin` to use cloud models.
 
 The extension discovers models from `http://127.0.0.1:11434` by default.
 
+### Configure context length
+
+If the Ollama server uses `OLLAMA_CONTEXT_LENGTH`, configure the extension with
+the same value. For example, if the server starts with:
+
+```sh
+OLLAMA_CONTEXT_LENGTH=65536 ollama serve
+```
+
+Open VS Code Settings with `Cmd+,` on macOS or `Ctrl+,` on Windows and Linux.
+Search for `Ollama: Max Context Length` and enter the same value. For the
+example above, add this to `settings.json` instead:
+
+```json
+{
+  "ollama.maxContextLength": 65536
+}
+```
+
+The extension refreshes the model list when the setting changes and reports a
+context window no larger than the configured value. The Ollama output channel
+confirms it with `capped at 65536 context tokens` for the example above.
+
+`Ollama: Max Context Length` is a setting. `Ollama: Refresh Models` is a
+separate command in the Command Palette.
+
 ## Commands
 
 The extension adds these commands to the Command Palette:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,12 @@
               "additionalProperties": {
                 "type": "string"
               }
+            },
+            "maxContextLength": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Maximum Context Length",
+              "description": "Maximum context length configured on this Ollama server. If the server uses OLLAMA_CONTEXT_LENGTH, enter the same value here."
             }
           }
         }
@@ -74,6 +80,11 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "ollama.maxContextLength": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum context length configured on the Ollama server. If the server uses OLLAMA_CONTEXT_LENGTH, enter the same value here. Provider configuration takes precedence when present."
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,12 @@ export function activate(context: vscode.ExtensionContext) {
     provider,
     vscode.lm.registerLanguageModelChatProvider(ollamaVendor, provider),
     vscode.commands.registerCommand('ollama.refreshModels', () => provider.refresh()),
-    vscode.commands.registerCommand('ollama.diagnoseModels', () => diagnoseModels(output))
+    vscode.commands.registerCommand('ollama.diagnoseModels', () => diagnoseModels(output)),
+    vscode.workspace.onDidChangeConfiguration(event => {
+      if (event.affectsConfiguration('ollama.maxContextLength')) {
+        provider.refresh();
+      }
+    })
   );
 }
 

--- a/src/modelLimits.ts
+++ b/src/modelLimits.ts
@@ -1,0 +1,77 @@
+export interface ModelTokenLimits {
+  maxInputTokens: number;
+  maxOutputTokens: number;
+}
+
+export function resolveMaxContextLength(
+  providerValue: unknown,
+  settingValue: unknown
+): number | undefined {
+  return positiveInteger(providerValue) ?? positiveInteger(settingValue);
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+export function calculateModelTokenLimits(
+  contextWindow: number | undefined,
+  explicitMaxInputTokens: number | undefined,
+  explicitMaxOutputTokens: number | undefined,
+  configuredMaxContextLength: number | undefined,
+  fallbackContextWindow: number,
+  defaultMaxOutputTokens: number
+): ModelTokenLimits {
+  const discoveredContextWindow = contextWindow
+    ?? (explicitMaxInputTokens === undefined ? fallbackContextWindow : undefined);
+
+  if (discoveredContextWindow === undefined) {
+    const maxInputTokens = explicitMaxInputTokens ?? fallbackContextWindow;
+    const maxOutputTokens = explicitMaxOutputTokens ?? defaultMaxOutputTokens;
+    if (configuredMaxContextLength === undefined
+      || maxInputTokens + maxOutputTokens <= configuredMaxContextLength) {
+      return { maxInputTokens, maxOutputTokens };
+    }
+
+    const cappedOutputTokens = outputTokenLimit(
+      configuredMaxContextLength,
+      maxOutputTokens,
+      defaultMaxOutputTokens
+    );
+    return {
+      maxInputTokens: Math.min(maxInputTokens, configuredMaxContextLength - cappedOutputTokens),
+      maxOutputTokens: cappedOutputTokens
+    };
+  }
+
+  const effectiveContextWindow = configuredMaxContextLength === undefined
+    ? discoveredContextWindow
+    : Math.min(configuredMaxContextLength, discoveredContextWindow);
+
+  const maxOutputTokens = outputTokenLimit(
+    effectiveContextWindow,
+    explicitMaxOutputTokens,
+    defaultMaxOutputTokens
+  );
+  return {
+    maxInputTokens: effectiveContextWindow - maxOutputTokens,
+    maxOutputTokens
+  };
+}
+
+function outputTokenLimit(
+  contextWindow: number,
+  configuredOutputLimit: number | undefined,
+  defaultMaxOutputTokens: number
+): number {
+  if (contextWindow <= 1) {
+    return 0;
+  }
+
+  return Math.min(
+    configuredOutputLimit ?? defaultMaxOutputTokens,
+    contextWindow - 1
+  );
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -22,11 +22,13 @@ import {
   recommendedReplacement
 } from './recommendations';
 import { createChatFetch } from './chatFetch';
+import { calculateModelTokenLimits, resolveMaxContextLength } from './modelLimits';
 
 interface OllamaProviderConfiguration {
   url: string;
   models: string[];
   headers: Record<string, string>;
+  maxContextLength?: number;
 }
 
 interface OllamaLanguageModel extends vscode.LanguageModelChatInformation {
@@ -164,8 +166,11 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
         const recommendationSuffix = recommendations.length > 0
           ? ` using ${recommendations.length} recommendation(s)`
           : '';
+        const contextLimitSuffix = configuration.maxContextLength === undefined
+          ? ''
+          : ` capped at ${configuration.maxContextLength} context tokens`;
         this.output?.appendLine(
-          `Providing ${models.length} Ollama model(s) from ${configuration.url}${versionSuffix}${recommendationSuffix}.`
+          `Providing ${models.length} Ollama model(s) from ${configuration.url}${versionSuffix}${recommendationSuffix}${contextLimitSuffix}.`
         );
 
         return hydratedModels.map(({ model, show }) => this.toLanguageModel(
@@ -369,7 +374,11 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
   ): OllamaLanguageModel {
     const capabilities = mergedCapabilities(model.capabilities, show?.capabilities);
     const name = model.name;
-    const { maxInputTokens, maxOutputTokens } = modelTokenLimits(model, show);
+    const { maxInputTokens, maxOutputTokens } = modelTokenLimits(
+      model,
+      show,
+      configuration.maxContextLength
+    );
 
     return {
       id: name,
@@ -511,7 +520,11 @@ function getConfiguration(options?: vscode.PrepareLanguageModelChatModelOptions)
     models: Array.isArray(configuration?.models)
       ? configuration.models.filter((model): model is string => typeof model === 'string' && model.length > 0)
       : [],
-    headers: getConfiguredHeaders(configuration, settings)
+    headers: getConfiguredHeaders(configuration, settings),
+    maxContextLength: resolveMaxContextLength(
+      configuration?.maxContextLength,
+      settings.get<number>('maxContextLength')
+    )
   };
 }
 
@@ -584,25 +597,21 @@ function modelFamily(model: OllamaTagsModel, show: OllamaShowResponse | undefine
     : model.name.split(':')[0] || model.name;
 }
 
-function modelTokenLimits(model: OllamaTagsModel, show: OllamaShowResponse | undefined) {
+function modelTokenLimits(
+  model: OllamaTagsModel,
+  show: OllamaShowResponse | undefined,
+  configuredMaxContextLength: number | undefined
+) {
   const explicitMaxInputTokens = explicitTokenLimit(model, show, 'input');
   const explicitMaxOutputTokens = explicitTokenLimit(model, show, 'output');
-  const contextWindow = sharedContextWindow(model, show)
-    ?? (explicitMaxInputTokens === undefined ? fallbackContextWindow : undefined);
-
-  if (contextWindow === undefined) {
-    return {
-      maxInputTokens: explicitMaxInputTokens ?? fallbackContextWindow,
-      maxOutputTokens: explicitMaxOutputTokens ?? defaultMaxOutputTokens
-    };
-  }
-
-  // VS Code displays input + output; Ollama reports one shared context window.
-  const maxOutputTokens = outputTokenLimit(contextWindow, explicitMaxOutputTokens);
-  return {
-    maxInputTokens: contextWindow - maxOutputTokens,
-    maxOutputTokens
-  };
+  return calculateModelTokenLimits(
+    sharedContextWindow(model, show),
+    explicitMaxInputTokens,
+    explicitMaxOutputTokens,
+    configuredMaxContextLength,
+    fallbackContextWindow,
+    defaultMaxOutputTokens
+  );
 }
 
 function explicitTokenLimit(
@@ -645,17 +654,6 @@ function sharedContextWindow(model: OllamaTagsModel, show: OllamaShowResponse | 
     }
   }
   return undefined;
-}
-
-function outputTokenLimit(contextWindow: number, configuredOutputLimit: number | undefined): number {
-  if (contextWindow <= 1) {
-    return 0;
-  }
-
-  return Math.min(
-    configuredOutputLimit ?? defaultMaxOutputTokens,
-    contextWindow - 1
-  );
 }
 
 function numericParameterValue(text: string | undefined, name: string): number | undefined {

--- a/test/modelLimits.test.js
+++ b/test/modelLimits.test.js
@@ -1,0 +1,75 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { calculateModelTokenLimits, resolveMaxContextLength } = require('../out/modelLimits');
+
+const fallbackContextWindow = 32768;
+const defaultMaxOutputTokens = 4096;
+
+function limits(contextWindow, configuredMaxContextLength, explicitMaxInputTokens, explicitMaxOutputTokens) {
+  return calculateModelTokenLimits(
+    contextWindow,
+    explicitMaxInputTokens,
+    explicitMaxOutputTokens,
+    configuredMaxContextLength,
+    fallbackContextWindow,
+    defaultMaxOutputTokens
+  );
+}
+
+test('keeps the discovered model context when no server limit is configured', () => {
+  assert.deepEqual(limits(131072), {
+    maxInputTokens: 126976,
+    maxOutputTokens: 4096
+  });
+});
+
+test('caps the advertised model context at the configured server limit', () => {
+  assert.deepEqual(limits(131072, 65536), {
+    maxInputTokens: 61440,
+    maxOutputTokens: 4096
+  });
+});
+
+test('does not raise a model context when the configured limit is larger', () => {
+  assert.deepEqual(limits(8192, 65536), {
+    maxInputTokens: 4096,
+    maxOutputTokens: 4096
+  });
+});
+
+test('uses the configured server limit when model metadata has no context', () => {
+  assert.deepEqual(limits(undefined, 16384), {
+    maxInputTokens: 12288,
+    maxOutputTokens: 4096
+  });
+});
+
+test('does not raise an explicit input limit while applying the server cap', () => {
+  assert.deepEqual(limits(undefined, 65536, 8000, 2000), {
+    maxInputTokens: 8000,
+    maxOutputTokens: 2000
+  });
+});
+
+test('keeps at least one input token for very small contexts', () => {
+  assert.deepEqual(limits(1, 1), {
+    maxInputTokens: 1,
+    maxOutputTokens: 0
+  });
+});
+
+test('prefers a valid provider context limit over the global setting', () => {
+  assert.equal(resolveMaxContextLength(65536, 32768), 65536);
+});
+
+test('falls back to the global setting when the provider value is invalid', () => {
+  for (const value of [undefined, null, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '65536']) {
+    assert.equal(resolveMaxContextLength(value, 32768), 32768);
+  }
+});
+
+test('ignores invalid context limits', () => {
+  for (const value of [undefined, null, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '65536']) {
+    assert.equal(resolveMaxContextLength(value, value), undefined);
+  }
+});


### PR DESCRIPTION
## Summary

Add a configurable maximum context length for Ollama servers.

Users can set `Ollama: Max Context Length` to the same value as the server's `OLLAMA_CONTEXT_LENGTH`. The extension caps the model context reported to VS Code without exceeding the model's native context window.

This replaces the need to patch the installed extension with a hard-coded limit.

The change also:

- Supports global and per-provider context limits.
- Refreshes the model list when the setting changes.
- Logs the configured cap in the Ollama output channel.
- Documents setup in the README.
- Preserves existing behavior when the setting is not configured.

Oversized one-shot requests that bypass VS Code's advertised limit remain unchanged and are tracked separately in #33.

Fixes #31.

## Testing

- Added tests for discovered, configured, fallback, and very small context windows.
- Added tests for provider-over-global precedence.
- Added tests for invalid context values.
- Verified manually with `OLLAMA_CONTEXT_LENGTH=8000`.
- Confirmed the output channel reports the configured value:

```text
capped at 8000 context tokens
```

- All 25 tests pass:

```sh
npm test
```
