### PR TITLE
Bump version to 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ollama",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ollama",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "ollama": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Ollama",
   "description": "Ollama language model provider for VS Code.",
   "publisher": "Ollama",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "icon": "images/icon.png",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- bump the extension version from `0.0.5` to `0.0.6`
- keep the root package version in `package-lock.json` synchronized

## Why

Version `0.0.6` is required to publish the Marketplace metadata changes merged in #39 as a new extension release. Marketplace versions cannot be overwritten.

## User impact

After this PR merges, maintainers can publish version `0.0.6` with `npx @vscode/vsce publish`.

## Validation

- `npm test` (16 tests passed)
- `git diff --check`
