### PR TITLE
Support thinking models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typescript": "^5.8.0"
       },
       "engines": {
-        "vscode": "^1.120.0"
+        "vscode": "^1.127.0"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "engines": {
     "vscode": "^1.127.0"
   },
+  "enabledApiProposals": [
+    "languageModelThinkingPart",
+    "chatProvider"
+  ],
   "categories": [
     "AI"
   ],

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -42,7 +42,7 @@ export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequ
       }
     }
 
-    if (text.length > 0 || images.length > 0 || toolCalls.length > 0) {
+    if (text.length > 0 || thinking.length > 0 || images.length > 0 || toolCalls.length > 0) {
       converted.push({
         role: roleToOllama(message.role),
         content: text.join('\n'),

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -7,6 +7,7 @@ export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequ
   for (const message of messages) {
     const text: string[] = [];
     const images: string[] = [];
+    const thinking: string[] = [];
     const toolCalls: NonNullable<OllamaChatMessage['tool_calls']> = [];
     const toolResults: OllamaChatMessage[] = [];
 
@@ -35,6 +36,9 @@ export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequ
           ...(result.images.length > 0 ? { images: result.images } : {}),
           tool_call_id: part.callId
         });
+      } else if (part instanceof vscode.LanguageModelThinkingPart) {
+        const parts = Array.isArray(part.value) ? part.value : [part.value];
+        thinking.push(...parts);
       }
     }
 
@@ -42,6 +46,7 @@ export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequ
       converted.push({
         role: roleToOllama(message.role),
         content: text.join('\n'),
+        ...(thinking.length > 0 ? { thinking: thinking.join('\n') } : {}),
         images: images.length > 0 ? images : undefined,
         tool_calls: toolCalls.length > 0 ? toolCalls : undefined
       });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -34,6 +34,15 @@ import {
   type OllamaDiagnosticsConfiguration,
   type OllamaDiagnosticsConfigurationSelection
 } from './diagnostics';
+import {
+  isThinkingLevel,
+  thinkingLevelDescription,
+  thinkingLevelLabel,
+  thinkingLevelProperty,
+  thinkingPolicy,
+  toOllamaThinkValue,
+  type ThinkingLevel
+} from './thinking';
 
 interface OllamaProviderConfiguration {
   url: string;
@@ -83,19 +92,8 @@ interface OllamaShowResponse extends Omit<ShowResponse, 'model_info'> {
   max_output_tokens?: number;
 }
 
-const OLLAMA_THINKING_EFFORT_PROPERTY = 'thinkingLevel';
-const OLLAMA_THINKING_EFFORT_LEVELS = ['none', 'low', 'medium', 'high'] as const;
-const OLLAMA_THINKING_EFFORT_DESCRIPTIONS = [
-  'No reasoning applied',
-  'Faster responses with less reasoning',
-  'Balanced reasoning and speed',
-  'Greater reasoning depth but slower'
-];
-const OLLAMA_THINKING_EFFORT_DEFAULT: OllamaThinkingEffortLevel = 'medium';
-
-type OllamaThinkingEffortLevel = (typeof OLLAMA_THINKING_EFFORT_LEVELS)[number];
 interface OllamaModelConfiguration extends vscode.LanguageModelConfigurationSchema {
-  [OLLAMA_THINKING_EFFORT_PROPERTY]?: OllamaThinkingEffortLevel;
+  [thinkingLevelProperty]?: ThinkingLevel;
 }
 
 type ModelInfo = Record<string, unknown> | Map<string, unknown>;
@@ -266,8 +264,8 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     try {
       let promptTokenCount: number | undefined;
       let completionTokenCount: number | undefined;
-      const rawThinkingLevel = options.modelConfiguration?.[OLLAMA_THINKING_EFFORT_PROPERTY];
-      const thinkingLevel: OllamaThinkingEffortLevel | undefined = OLLAMA_THINKING_EFFORT_LEVELS.includes(rawThinkingLevel)
+      const rawThinkingLevel = options.modelConfiguration?.[thinkingLevelProperty];
+      const thinkingLevel: ThinkingLevel | undefined = isThinkingLevel(rawThinkingLevel)
         ? rawThinkingLevel
         : undefined;
 
@@ -277,7 +275,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
         messages: ollamaMessages,
         stream: true,
         tools: tools.length > 0 ? tools : undefined,
-        think: thinkingLevel == 'none' ? false : thinkingLevel,
+        think: toOllamaThinkValue(thinkingLevel),
         options: options.modelOptions ? { ...options.modelOptions } : undefined
       } as ChatRequest & { stream: true });
       void streamRequest.then(
@@ -528,12 +526,28 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
   ): OllamaLanguageModel {
     const capabilities = mergedCapabilities(model.capabilities, show?.capabilities);
     const name = model.name;
+    const family = modelFamily(model, show);
+    const policy = thinkingPolicy(name, family);
+    let thinkingProperties: NonNullable<vscode.LanguageModelConfigurationSchema['properties']> = {};
+    if (hasCapability(capabilities, 'thinking', 'reasoning') && policy) {
+      thinkingProperties = {
+        [thinkingLevelProperty]: {
+          type: 'string',
+          title: 'Thinking Effort',
+          enum: policy.levels,
+          enumItemLabels: policy.levels.map(thinkingLevelLabel),
+          enumDescriptions: policy.levels.map(thinkingLevelDescription),
+          default: policy.defaultLevel,
+          group: 'navigation'
+        }
+      };
+    }
     const { maxInputTokens, maxOutputTokens } = modelTokenLimits(model, show);
 
     return {
       id: name,
       name,
-      family: modelFamily(model, show),
+      family,
       tooltip: recommended ? 'Recommended' : name,
       version: '1.0',
       maxInputTokens,
@@ -548,17 +562,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       local: !isRemoteModel(model) && !isCloudModel(name),
       recommendedReplacement: replacement,
       configurationSchema: {
-        properties: hasCapability(capabilities, 'thinking', 'reasoning') ? {
-          [OLLAMA_THINKING_EFFORT_PROPERTY]: {
-            type: 'string',
-            title: 'Thinking Effort',
-            enum: OLLAMA_THINKING_EFFORT_LEVELS,
-            enumItemLabels: OLLAMA_THINKING_EFFORT_LEVELS.map(level => level.charAt(0).toUpperCase() + level.slice(1)),
-            enumDescriptions: OLLAMA_THINKING_EFFORT_DESCRIPTIONS,
-            default: OLLAMA_THINKING_EFFORT_DEFAULT,
-            group: 'navigation'
-          }
-        } : {}
+        properties: thinkingProperties
       }
     };
   }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -35,12 +35,13 @@ import {
   type OllamaDiagnosticsConfigurationSelection
 } from './diagnostics';
 import {
-  isThinkingLevel,
+  supportedThinkingLevel,
   thinkingLevelDescription,
   thinkingLevelLabel,
   thinkingLevelProperty,
   thinkingPolicy,
   toOllamaThinkValue,
+  type ThinkingPolicy,
   type ThinkingLevel
 } from './thinking';
 
@@ -55,6 +56,7 @@ interface OllamaLanguageModel extends vscode.LanguageModelChatInformation {
   url: string;
   headers: Record<string, string>;
   local: boolean;
+  thinkingPolicy?: ThinkingPolicy;
   recommendedReplacement?: string;
 }
 
@@ -265,9 +267,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       let promptTokenCount: number | undefined;
       let completionTokenCount: number | undefined;
       const rawThinkingLevel = options.modelConfiguration?.[thinkingLevelProperty];
-      const thinkingLevel: ThinkingLevel | undefined = isThinkingLevel(rawThinkingLevel)
-        ? rawThinkingLevel
-        : undefined;
+      const thinkingLevel = supportedThinkingLevel(model.thinkingPolicy, rawThinkingLevel);
 
       let chatRequestSettled = false;
       const streamRequest = ollama.chat({
@@ -560,6 +560,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       url: configuration.url,
       headers: configuration.headers,
       local: !isRemoteModel(model) && !isCloudModel(name),
+      thinkingPolicy: policy,
       recommendedReplacement: replacement,
       configurationSchema: {
         properties: thinkingProperties

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -83,6 +83,21 @@ interface OllamaShowResponse extends Omit<ShowResponse, 'model_info'> {
   max_output_tokens?: number;
 }
 
+const OLLAMA_THINKING_EFFORT_PROPERTY = 'thinkingLevel';
+const OLLAMA_THINKING_EFFORT_LEVELS = ['none', 'low', 'medium', 'high'] as const;
+const OLLAMA_THINKING_EFFORT_DESCRIPTIONS = [
+  'No reasoning applied',
+  'Faster responses with less reasoning',
+  'Balanced reasoning and speed',
+  'Greater reasoning depth but slower'
+];
+const OLLAMA_THINKING_EFFORT_DEFAULT: OllamaThinkingEffortLevel = 'medium';
+
+type OllamaThinkingEffortLevel = (typeof OLLAMA_THINKING_EFFORT_LEVELS)[number];
+interface OllamaModelConfiguration extends vscode.LanguageModelConfigurationSchema {
+  [OLLAMA_THINKING_EFFORT_PROPERTY]?: OllamaThinkingEffortLevel;
+}
+
 type ModelInfo = Record<string, unknown> | Map<string, unknown>;
 
 export interface OllamaChatMessage extends Message {
@@ -111,6 +126,7 @@ interface OllamaToolCall extends ToolCall {
 interface OllamaChatResponse extends Partial<Omit<ChatResponse, 'message'>> {
   message?: {
     content?: string;
+    thinking?: string;
     tool_calls?: OllamaToolCall[];
   };
   done?: boolean;
@@ -212,7 +228,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     model: OllamaLanguageModel,
     messages: readonly vscode.LanguageModelChatRequestMessage[],
     options: vscode.ProvideLanguageModelChatResponseOptions,
-    progress: vscode.Progress<vscode.LanguageModelResponsePart>,
+    progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
     token: vscode.CancellationToken
   ): Promise<void> {
     const ollamaMessages = toOllamaMessages(messages);
@@ -250,12 +266,18 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     try {
       let promptTokenCount: number | undefined;
       let completionTokenCount: number | undefined;
+      const rawThinkingLevel = options.modelConfiguration?.[OLLAMA_THINKING_EFFORT_PROPERTY];
+      const thinkingLevel: OllamaThinkingEffortLevel | undefined = OLLAMA_THINKING_EFFORT_LEVELS.includes(rawThinkingLevel)
+        ? rawThinkingLevel
+        : undefined;
+
       let chatRequestSettled = false;
       const streamRequest = ollama.chat({
         model: model.model,
         messages: ollamaMessages,
         stream: true,
         tools: tools.length > 0 ? tools : undefined,
+        think: thinkingLevel == 'none' ? false : thinkingLevel,
         options: options.modelOptions ? { ...options.modelOptions } : undefined
       } as ChatRequest & { stream: true });
       void streamRequest.then(
@@ -307,6 +329,10 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
         }
 
         const content = response.message?.content;
+        const thinking = response.message?.thinking;
+        if (thinking) {
+          progress.report(new vscode.LanguageModelThinkingPart(thinking))
+        }
         if (content) {
           progress.report(new vscode.LanguageModelTextPart(content));
         }
@@ -520,7 +546,20 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       url: configuration.url,
       headers: configuration.headers,
       local: !isRemoteModel(model) && !isCloudModel(name),
-      recommendedReplacement: replacement
+      recommendedReplacement: replacement,
+      configurationSchema: {
+        properties: hasCapability(capabilities, 'thinking', 'reasoning') ? {
+          [OLLAMA_THINKING_EFFORT_PROPERTY]: {
+            type: 'string',
+            title: 'Thinking Effort',
+            enum: OLLAMA_THINKING_EFFORT_LEVELS,
+            enumItemLabels: OLLAMA_THINKING_EFFORT_LEVELS.map(level => level.charAt(0).toUpperCase() + level.slice(1)),
+            enumDescriptions: OLLAMA_THINKING_EFFORT_DESCRIPTIONS,
+            default: OLLAMA_THINKING_EFFORT_DEFAULT,
+            group: 'navigation'
+          }
+        } : {}
+      }
     };
   }
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -329,7 +329,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
         const content = response.message?.content;
         const thinking = response.message?.thinking;
         if (thinking) {
-          progress.report(new vscode.LanguageModelThinkingPart(thinking))
+          progress.report(new vscode.LanguageModelThinkingPart(thinking));
         }
         if (content) {
           progress.report(new vscode.LanguageModelTextPart(content));

--- a/src/thinking.ts
+++ b/src/thinking.ts
@@ -36,7 +36,7 @@ export function thinkingPolicy(modelName: string, family?: string): ThinkingPoli
   if (identifiers.some(value => value === 'deepseek-v4-flash' || value === 'deepseek-v4-pro')) {
     return {
       levels: ['none', 'high', 'max'],
-      defaultLevel: 'high'
+      defaultLevel: 'none'
     };
   }
 
@@ -58,7 +58,13 @@ export function supportedThinkingLevel(
   policy: ThinkingPolicy | undefined,
   value: unknown
 ): ThinkingLevel | undefined {
-  if (!policy || !isThinkingLevel(value)) {
+  if (!policy) {
+    return undefined;
+  }
+  if (value === undefined) {
+    return policy.defaultLevel;
+  }
+  if (!isThinkingLevel(value)) {
     return undefined;
   }
   return policy.levels.includes(value) ? value : undefined;

--- a/src/thinking.ts
+++ b/src/thinking.ts
@@ -9,6 +9,13 @@ export interface ThinkingPolicy {
   defaultLevel: ThinkingLevel;
 }
 
+// Keep this inventory aligned with the model documentation published on
+// ollama.com/library. These mappings were last verified on 2026-08-11:
+// - https://ollama.com/library/gpt-oss
+// - https://ollama.com/library/deepseek-v4-flash
+// - https://ollama.com/library/deepseek-v4-pro
+// - https://ollama.com/library/glm-5.2
+
 /**
  * Return only thinking controls documented for a known Ollama model family.
  * Ollama's generic `thinking` capability does not expose the accepted values,

--- a/src/thinking.ts
+++ b/src/thinking.ts
@@ -47,6 +47,16 @@ export function isThinkingLevel(value: unknown): value is ThinkingLevel {
   return typeof value === 'string' && (thinkingLevels as readonly string[]).includes(value);
 }
 
+export function supportedThinkingLevel(
+  policy: ThinkingPolicy | undefined,
+  value: unknown
+): ThinkingLevel | undefined {
+  if (!policy || !isThinkingLevel(value)) {
+    return undefined;
+  }
+  return policy.levels.includes(value) ? value : undefined;
+}
+
 export function toOllamaThinkValue(level: ThinkingLevel | undefined): OllamaThinkValue | undefined {
   if (level === undefined) {
     return undefined;

--- a/src/thinking.ts
+++ b/src/thinking.ts
@@ -1,0 +1,82 @@
+export const thinkingLevelProperty = 'thinkingLevel';
+
+export const thinkingLevels = ['none', 'low', 'medium', 'high', 'max'] as const;
+export type ThinkingLevel = (typeof thinkingLevels)[number];
+export type OllamaThinkValue = boolean | Exclude<ThinkingLevel, 'none'>;
+
+export interface ThinkingPolicy {
+  levels: readonly ThinkingLevel[];
+  defaultLevel: ThinkingLevel;
+}
+
+/**
+ * Return only thinking controls documented for a known Ollama model family.
+ * Ollama's generic `thinking` capability does not expose the accepted values,
+ * so unknown models do not receive a control rather than guessing.
+ */
+export function thinkingPolicy(modelName: string, family?: string): ThinkingPolicy | undefined {
+  const identifiers = [modelNameWithoutTag(modelName), family]
+    .filter((value): value is string => typeof value === 'string')
+    .map(normalizeIdentifier);
+
+  if (identifiers.some(value => value === 'gpt-oss' || value === 'gptoss')) {
+    return {
+      levels: ['low', 'medium', 'high'],
+      defaultLevel: 'medium'
+    };
+  }
+
+  if (identifiers.some(value => value === 'deepseek-v4-flash' || value === 'deepseek-v4-pro')) {
+    return {
+      levels: ['none', 'high', 'max'],
+      defaultLevel: 'high'
+    };
+  }
+
+  if (identifiers.some(value => value === 'glm-5.2' || value === 'glm5.2')) {
+    return {
+      levels: ['high', 'max'],
+      defaultLevel: 'high'
+    };
+  }
+
+  return undefined;
+}
+
+export function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return typeof value === 'string' && (thinkingLevels as readonly string[]).includes(value);
+}
+
+export function toOllamaThinkValue(level: ThinkingLevel | undefined): OllamaThinkValue | undefined {
+  if (level === undefined) {
+    return undefined;
+  }
+  return level === 'none' ? false : level;
+}
+
+export function thinkingLevelLabel(level: ThinkingLevel): string {
+  return level.charAt(0).toUpperCase() + level.slice(1);
+}
+
+export function thinkingLevelDescription(level: ThinkingLevel): string {
+  switch (level) {
+    case 'none': return 'Disable thinking';
+    case 'low': return 'Use low thinking effort';
+    case 'medium': return 'Use medium thinking effort';
+    case 'high': return 'Use high thinking effort';
+    case 'max': return 'Use maximum thinking effort';
+  }
+}
+
+function modelNameWithoutTag(modelName: string): string {
+  const cloudSuffix = ':cloud';
+  const normalized = modelName.toLowerCase();
+  if (normalized.endsWith(cloudSuffix)) {
+    return normalized.slice(0, -cloudSuffix.length);
+  }
+  return normalized.split(':', 1)[0];
+}
+
+function normalizeIdentifier(value: string): string {
+  return value.trim().toLowerCase().replaceAll('_', '-');
+}

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -25,6 +25,12 @@ class LanguageModelDataPart {
 
 class LanguageModelToolCallPart {}
 
+class LanguageModelThinkingPart {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
 class LanguageModelToolResultPart {
   constructor(callId, content) {
     this.callId = callId;
@@ -36,6 +42,7 @@ const vscode = {
   LanguageModelChatMessageRole: { User: 1, Assistant: 2, System: 3 },
   LanguageModelDataPart,
   LanguageModelTextPart,
+  LanguageModelThinkingPart,
   LanguageModelToolCallPart,
   LanguageModelToolResultPart
 };
@@ -125,5 +132,34 @@ test('forwards image data from tool results on the corresponding tool message', 
     content: 'browser screenshot',
     images: [Buffer.from(imageBytes).toString('base64')],
     tool_call_id: 'call-4'
+  }]);
+});
+
+test('preserves thinking content in assistant history', () => {
+  assert.deepEqual(toOllamaMessages([{
+    role: 2,
+    content: [
+      new LanguageModelThinkingPart(['first thought', 'second thought']),
+      new LanguageModelTextPart('answer')
+    ]
+  }]), [{
+    role: 'assistant',
+    content: 'answer',
+    thinking: 'first thought\nsecond thought',
+    images: undefined,
+    tool_calls: undefined
+  }]);
+});
+
+test('preserves an assistant history message that contains only thinking', () => {
+  assert.deepEqual(toOllamaMessages([{
+    role: 2,
+    content: [new LanguageModelThinkingPart('thought without final text')]
+  }]), [{
+    role: 'assistant',
+    content: '',
+    thinking: 'thought without final text',
+    images: undefined,
+    tool_calls: undefined
   }]);
 });

--- a/test/provider-thinking.test.js
+++ b/test/provider-thinking.test.js
@@ -1,0 +1,147 @@
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+class Disposable {
+  dispose() {}
+}
+
+class EventEmitter {
+  event = () => new Disposable();
+  fire() {}
+  dispose() {}
+}
+
+class CancellationTokenSource {
+  token = cancellationToken;
+  cancel() {}
+  dispose() {}
+}
+
+class LanguageModelTextPart {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class LanguageModelDataPart {
+  constructor(data, mimeType) {
+    this.data = data;
+    this.mimeType = mimeType;
+  }
+}
+
+class LanguageModelThinkingPart extends LanguageModelTextPart {}
+class LanguageModelToolCallPart {}
+class LanguageModelToolResultPart {}
+
+const cancellationToken = {
+  isCancellationRequested: false,
+  onCancellationRequested: () => new Disposable()
+};
+
+const vscode = {
+  CancellationError: class CancellationError extends Error {},
+  CancellationTokenSource,
+  EventEmitter,
+  LanguageModelChatMessageRole: { User: 1, Assistant: 2, System: 3 },
+  LanguageModelDataPart,
+  LanguageModelTextPart,
+  LanguageModelThinkingPart,
+  LanguageModelToolCallPart,
+  LanguageModelToolResultPart,
+  commands: { executeCommand: async () => undefined },
+  env: { openExternal: async () => undefined },
+  window: {
+    showErrorMessage: async () => undefined,
+    showWarningMessage: async () => undefined
+  },
+  workspace: {
+    getConfiguration: () => ({ get: (_key, fallback) => fallback })
+  }
+};
+
+let models = [];
+let chatRequests = [];
+
+class Ollama {
+  async version() {
+    return { version: 'test' };
+  }
+
+  async list() {
+    return { models };
+  }
+
+  async show({ model }) {
+    return models.find(candidate => candidate.name === model)?.show ?? {};
+  }
+
+  async chat(request) {
+    chatRequests.push(request);
+    return {
+      abort() {},
+      async *[Symbol.asyncIterator]() {
+        yield { done: true, message: {} };
+      }
+    };
+  }
+}
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'vscode') {
+    return vscode;
+  }
+  if (request === 'ollama') {
+    return { Ollama };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+let OllamaLanguageModelProvider;
+try {
+  ({ OllamaLanguageModelProvider } = require('../out/provider'));
+} finally {
+  Module._load = originalLoad;
+}
+
+test.beforeEach(() => {
+  models = [];
+  chatRequests = [];
+});
+
+test('omits a stale thinking value from the actual Ollama request', async () => {
+  models = [{ name: 'gpt-oss:20b', capabilities: ['thinking'], remote_host: 'ollama.com' }];
+  const provider = new OllamaLanguageModelProvider();
+  const [model] = await provider.provideLanguageModelChatInformation({}, cancellationToken);
+
+  await provider.provideLanguageModelChatResponse(
+    model,
+    [{ role: 1, content: [new LanguageModelTextPart('hello')] }],
+    { modelConfiguration: { thinkingLevel: 'none' } },
+    { report() {} },
+    cancellationToken
+  );
+
+  assert.equal(chatRequests.length, 1);
+  assert.equal(chatRequests[0].think, undefined);
+});
+
+test('exposes thinking controls only with both a verified policy and server capability', async () => {
+  models = [
+    { name: 'gpt-oss:20b', capabilities: ['thinking'], remote_host: 'ollama.com' },
+    { name: 'gpt-oss:120b', capabilities: ['tools'], remote_host: 'ollama.com' },
+    { name: 'unknown-thinking:cloud', capabilities: ['thinking'], remote_host: 'ollama.com' }
+  ];
+  const provider = new OllamaLanguageModelProvider();
+  const discovered = await provider.provideLanguageModelChatInformation({}, cancellationToken);
+  const properties = Object.fromEntries(discovered.map(model => [
+    model.id,
+    model.configurationSchema.properties
+  ]));
+
+  assert.deepEqual(properties['gpt-oss:20b'].thinkingLevel.enum, ['low', 'medium', 'high']);
+  assert.equal(properties['gpt-oss:120b'].thinkingLevel, undefined);
+  assert.equal(properties['unknown-thinking:cloud'].thinkingLevel, undefined);
+});

--- a/test/provider-thinking.test.js
+++ b/test/provider-thinking.test.js
@@ -111,6 +111,23 @@ test.beforeEach(() => {
   chatRequests = [];
 });
 
+test('sends the policy default when VS Code omits an unset model configuration', async () => {
+  models = [{ name: 'deepseek-v4-flash:cloud', capabilities: ['thinking'], remote_host: 'ollama.com' }];
+  const provider = new OllamaLanguageModelProvider();
+  const [model] = await provider.provideLanguageModelChatInformation({}, cancellationToken);
+
+  await provider.provideLanguageModelChatResponse(
+    model,
+    [{ role: 1, content: [new LanguageModelTextPart('hello')] }],
+    { modelConfiguration: {} },
+    { report() {} },
+    cancellationToken
+  );
+
+  assert.equal(chatRequests.length, 1);
+  assert.equal(chatRequests[0].think, false);
+});
+
 test('omits a stale thinking value from the actual Ollama request', async () => {
   models = [{ name: 'gpt-oss:20b', capabilities: ['thinking'], remote_host: 'ollama.com' }];
   const provider = new OllamaLanguageModelProvider();

--- a/test/thinking.test.js
+++ b/test/thinking.test.js
@@ -21,7 +21,7 @@ test('uses documented GPT-OSS effort levels and does not offer disabling', () =>
 test('uses documented DeepSeek V4 non-thinking, high, and max modes', () => {
   const expected = {
     levels: ['none', 'high', 'max'],
-    defaultLevel: 'high'
+    defaultLevel: 'none'
   };
 
   assert.deepEqual(thinkingPolicy('deepseek-v4-flash:cloud'), expected);
@@ -54,14 +54,17 @@ test('translates UI thinking levels to Ollama request values', () => {
 
 test('accepts only levels supported by the selected model policy', () => {
   const gptOSS = thinkingPolicy('gpt-oss:20b');
+  assert.equal(supportedThinkingLevel(gptOSS, undefined), 'medium');
   assert.equal(supportedThinkingLevel(gptOSS, 'low'), 'low');
   assert.equal(supportedThinkingLevel(gptOSS, 'none'), undefined);
 
   const deepSeekV4 = thinkingPolicy('deepseek-v4-flash:cloud');
+  assert.equal(supportedThinkingLevel(deepSeekV4, undefined), 'none');
   assert.equal(supportedThinkingLevel(deepSeekV4, 'max'), 'max');
   assert.equal(supportedThinkingLevel(deepSeekV4, 'low'), undefined);
 
   const glm52 = thinkingPolicy('glm-5.2:cloud');
+  assert.equal(supportedThinkingLevel(glm52, undefined), 'high');
   assert.equal(supportedThinkingLevel(glm52, 'high'), 'high');
   assert.equal(supportedThinkingLevel(glm52, 'medium'), undefined);
 });

--- a/test/thinking.test.js
+++ b/test/thinking.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  thinkingPolicy,
+  toOllamaThinkValue
+} = require('../out/thinking');
+
+test('uses documented GPT-OSS effort levels and does not offer disabling', () => {
+  assert.deepEqual(thinkingPolicy('gpt-oss:20b'), {
+    levels: ['low', 'medium', 'high'],
+    defaultLevel: 'medium'
+  });
+  assert.deepEqual(thinkingPolicy('custom-name', 'gptoss'), {
+    levels: ['low', 'medium', 'high'],
+    defaultLevel: 'medium'
+  });
+});
+
+test('uses documented DeepSeek V4 non-thinking, high, and max modes', () => {
+  const expected = {
+    levels: ['none', 'high', 'max'],
+    defaultLevel: 'high'
+  };
+
+  assert.deepEqual(thinkingPolicy('deepseek-v4-flash:cloud'), expected);
+  assert.deepEqual(thinkingPolicy('deepseek-v4-pro:cloud'), expected);
+});
+
+test('uses documented GLM 5.2 high and max effort levels', () => {
+  const expected = {
+    levels: ['high', 'max'],
+    defaultLevel: 'high'
+  };
+
+  assert.deepEqual(thinkingPolicy('glm-5.2:cloud'), expected);
+  assert.deepEqual(thinkingPolicy('custom-name', 'glm5.2'), expected);
+});
+
+test('does not expose a control for models without a verified mapping', () => {
+  assert.equal(thinkingPolicy('qwen3.6:35b'), undefined);
+  assert.equal(thinkingPolicy('my-deepseek-v4-experiment'), undefined);
+});
+
+test('translates UI thinking levels to Ollama request values', () => {
+  assert.equal(toOllamaThinkValue(undefined), undefined);
+  assert.equal(toOllamaThinkValue('none'), false);
+  assert.equal(toOllamaThinkValue('low'), 'low');
+  assert.equal(toOllamaThinkValue('medium'), 'medium');
+  assert.equal(toOllamaThinkValue('high'), 'high');
+  assert.equal(toOllamaThinkValue('max'), 'max');
+});

--- a/test/thinking.test.js
+++ b/test/thinking.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const {
+  supportedThinkingLevel,
   thinkingPolicy,
   toOllamaThinkValue
 } = require('../out/thinking');
@@ -49,4 +50,23 @@ test('translates UI thinking levels to Ollama request values', () => {
   assert.equal(toOllamaThinkValue('medium'), 'medium');
   assert.equal(toOllamaThinkValue('high'), 'high');
   assert.equal(toOllamaThinkValue('max'), 'max');
+});
+
+test('accepts only levels supported by the selected model policy', () => {
+  const gptOSS = thinkingPolicy('gpt-oss:20b');
+  assert.equal(supportedThinkingLevel(gptOSS, 'low'), 'low');
+  assert.equal(supportedThinkingLevel(gptOSS, 'none'), undefined);
+
+  const deepSeekV4 = thinkingPolicy('deepseek-v4-flash:cloud');
+  assert.equal(supportedThinkingLevel(deepSeekV4, 'max'), 'max');
+  assert.equal(supportedThinkingLevel(deepSeekV4, 'low'), undefined);
+
+  const glm52 = thinkingPolicy('glm-5.2:cloud');
+  assert.equal(supportedThinkingLevel(glm52, 'high'), 'high');
+  assert.equal(supportedThinkingLevel(glm52, 'medium'), undefined);
+});
+
+test('omits stale configuration for models without a verified policy', () => {
+  assert.equal(supportedThinkingLevel(undefined, 'high'), undefined);
+  assert.equal(supportedThinkingLevel(undefined, 'invalid'), undefined);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "skipLibCheck": true
   },
   "include": [
-    "src"
+    "src",
+    "vscode.proposed.*.d.ts"
   ]
 }

--- a/vscode.proposed.chatProvider.d.ts
+++ b/vscode.proposed.chatProvider.d.ts
@@ -1,0 +1,187 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	/**
+	* The provider version of {@linkcode LanguageModelChatRequestOptions}
+	*/
+	export interface ProvideLanguageModelChatResponseOptions {
+
+		/**
+		 * What extension initiated the request to the language model, or
+		 * `undefined` if the request was initiated by other functionality in the editor.
+		 */
+		readonly requestInitiator: string;
+
+		/**
+		 * Per-model configuration provided by the user. This contains values configured
+		 * in the user's language models configuration file, validated against the model's
+		 * {@linkcode LanguageModelChatInformation.configurationSchema configurationSchema}.
+		 */
+		readonly modelConfiguration?: {
+			readonly [key: string]: any;
+		};
+
+		/**
+		 * Whether encrypted thinking state should be included in the response.
+		 */
+		readonly includeEncryptedThinking?: boolean;
+	}
+
+	/**
+	 * All the information representing a single language model contributed by a {@linkcode LanguageModelChatProvider}.
+	 */
+	export interface LanguageModelChatInformation {
+
+		/**
+		 * When present, this gates the use of `requestLanguageModelAccess` behind an authorization flow where
+		 * the user must approve of another extension accessing the models contributed by this extension.
+		 * Additionally, the extension can provide a label that will be shown in the UI.
+		 * A common example of a label is an account name that is signed in.
+		 *
+		 */
+		requiresAuthorization?: true | { label: string };
+
+		/**
+		 * A numeric value for comparing model cost tiers.
+		 */
+		readonly multiplierNumeric?: number;
+
+		/**
+		 * Whether this model is a "bring your own key" (BYOK) model, i.e. it is
+		 * served using credentials the user supplied rather than through the
+		 * built-in Copilot (CAPI) service. When unset, the model is treated as
+		 * a non-BYOK / CAPI-served model.
+		 */
+		readonly isBYOK?: boolean;
+
+		/**
+		 * Whether or not this will be selected by default in the model picker
+		 * NOT BEING FINALIZED
+		 */
+		readonly isDefault?: boolean | { [K in ChatLocation]?: boolean };
+
+		/**
+		 * Whether or not the model will show up in the model picker immediately upon being made known via {@linkcode LanguageModelChatProvider.provideLanguageModelChatInformation}.
+		 * NOT BEING FINALIZED
+		 */
+		readonly isUserSelectable?: boolean;
+
+		readonly statusIcon?: ThemeIcon;
+
+		/**
+		 * An optional JSON schema describing the configuration options for this model.
+		 * When set, users can specify per-model configuration in their language models
+		 * configuration file. The configured values are merged into the request options
+		 * when sending chat requests to this model.
+		 */
+		readonly configurationSchema?: LanguageModelConfigurationSchema;
+
+		/**
+		 * When set, this model is only shown in the model picker for the specified chat session type.
+		 * Models with this property are excluded from the general model picker and only appear
+		 * when the user is in a session matching this type.
+		 *
+		 * The value must match a `type` declared in a `chatSessions` extension contribution.
+		 */
+		readonly targetChatSessionType?: string;
+
+		/**
+		 * Optional warning text to display in the model picker hover as a warning banner.
+		 * The keys are warning categories (e.g. "data_retention") and the values are markdown strings.
+		 * Unlike degradation warnings, this does not produce a warning icon in the picker list.
+		 */
+		readonly warningText?: Record<string, string>;
+
+		/**
+		 * Optional promotional information for this model. When present, indicates the model
+		 * is currently experiencing a promotional discount.
+		 */
+		readonly promo?: {
+			/** Unique identifier for the promotion. */
+			readonly id: string;
+			/** The discount percentage (e.g. 20 for 20% off). */
+			readonly discountPercent: number;
+			/** ISO 8601 date string indicating when the promotion ends. */
+			readonly endsAt: string;
+			/** A human-readable message about the promotion. */
+			readonly message: string;
+		};
+	}
+
+	export interface LanguageModelChatCapabilities {
+		/**
+		 * The tools the model prefers for making file edits. If not provided or if none of the tools,
+		 * are recognized, the editor will try multiple edit tools and pick the best one. The available
+		 * edit tools WILL change over time and this capability only serves as a hint to the editor.
+		 *
+		 * Edit tools currently recognized include:
+		 * - 'find-replace': Find and replace text in a document.
+		 * - 'multi-find-replace': Find and replace multiple text snippets across documents.
+		 * - 'apply-patch': A file-oriented diff format used by some OpenAI models
+		 * - 'code-rewrite': A general but slower editing tool that allows the model
+		 *   to rewrite and code snippet and provide only the replacement to the editor.
+		 *
+		 * The order of edit tools in this array has no significance; all of the recognized edit
+		 * tools will be made available to the model.
+		 */
+		readonly editTools?: string[];
+	}
+
+	export type LanguageModelResponsePart2 = LanguageModelResponsePart | LanguageModelDataPart | LanguageModelThinkingPart;
+
+	/**
+	 * A [JSON Schema](https://json-schema.org) describing configuration options for a language model.
+	 * Each property in `properties` defines a configurable option using standard JSON Schema fields
+	 * plus additional display hints.
+	 */
+	export type LanguageModelConfigurationSchema = {
+		readonly properties?: {
+			readonly [key: string]: Record<string, any> & {
+				/**
+				 * Human-readable labels for enum values, shown instead of the raw values.
+				 * Must have the same length and order as `enum`.
+				 */
+				readonly enumItemLabels?: string[];
+				/**
+				 * The group this property belongs to. When set to `'navigation'`, the property
+				 * is shown as a primary action in the model picker.
+				 */
+				readonly group?: string;
+			};
+		};
+	};
+
+	export interface LanguageModelChatProvider<T extends LanguageModelChatInformation = LanguageModelChatInformation> {
+		provideLanguageModelChatInformation(options: PrepareLanguageModelChatModelOptions, token: CancellationToken): ProviderResult<T[]>;
+		provideLanguageModelChatResponse(model: T, messages: readonly LanguageModelChatRequestMessage[], options: ProvideLanguageModelChatResponseOptions, progress: Progress<LanguageModelResponsePart2>, token: CancellationToken): Thenable<void>;
+	}
+
+	/**
+	 * The list of options passed into {@linkcode LanguageModelChatProvider.provideLanguageModelChatInformation}
+	 */
+	export interface PrepareLanguageModelChatModelOptions {
+		/**
+		 * Configuration for the model. This is only present if the provider has declared that it requires configuration via the `configuration` property.
+		 * The object adheres to the schema that the extension provided during declaration.
+		 */
+		readonly configuration?: {
+			readonly [key: string]: any;
+		};
+	}
+
+	export interface ChatRequest {
+		/**
+		 * Per-model configuration provided by the user. Contains resolved values based on the model's
+		 * {@linkcode LanguageModelChatInformation.configurationSchema configurationSchema},
+		 * with user overrides applied on top of schema defaults.
+		 *
+		 * This is the same data that is sent as {@linkcode ProvideLanguageModelChatResponseOptions.configuration}
+		 * when the model is invoked via the language model API.
+		 */
+		readonly modelConfiguration?: { readonly [key: string]: any };
+	}
+}

--- a/vscode.proposed.languageModelThinkingPart.d.ts
+++ b/vscode.proposed.languageModelThinkingPart.d.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	/**
+	 * A language model response part containing thinking/reasoning content.
+	 * Thinking tokens represent the model's internal reasoning process that
+	 * typically streams before the final response.
+	 */
+	export class LanguageModelThinkingPart {
+		/**
+		 * The thinking/reasoning text content.
+		 */
+		value: string | string[];
+
+		/**
+		 * Optional unique identifier for this thinking sequence.
+		 * This ID is typically provided at the end of the thinking stream
+		 * and can be used for retrieval or reference purposes.
+		 */
+		id?: string;
+
+		/**
+		 * Optional metadata associated with this thinking sequence.
+		 */
+		metadata?: { readonly [key: string]: any };
+
+		/**
+		 * Construct a thinking part with the given content.
+		 * @param value The thinking text content.
+		 * @param id Optional unique identifier for this thinking sequence.
+		 * @param metadata Optional metadata associated with this thinking sequence.
+		 */
+		constructor(value: string | string[], id?: string, metadata?: { readonly [key: string]: any });
+	}
+
+	export interface LanguageModelChatResponse {
+		/**
+		 * An async iterable that is a stream of text, thinking, and tool-call parts forming the overall response.
+		 * This includes {@link LanguageModelThinkingPart} which represents the model's internal reasoning process.
+		 */
+		stream: AsyncIterable<LanguageModelTextPart | LanguageModelThinkingPart | LanguageModelToolCallPart | unknown>;
+	}
+
+	export interface LanguageModelChat {
+		sendRequest(messages: Array<LanguageModelChatMessage | LanguageModelChatMessage2>, options?: LanguageModelChatRequestOptions, token?: CancellationToken): Thenable<LanguageModelChatResponse>;
+		countTokens(text: string | LanguageModelChatMessage | LanguageModelChatMessage2, token?: CancellationToken): Thenable<number>;
+	}
+
+	/**
+	 * Represents a message in a chat. Can assume different roles, like user or assistant.
+	 */
+	export class LanguageModelChatMessage2 {
+
+		/**
+		 * Utility to create a new user message.
+		 *
+		 * @param content The content of the message.
+		 * @param name The optional name of a user for the message.
+		 */
+		static User(content: string | Array<LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelDataPart>, name?: string): LanguageModelChatMessage2;
+
+		/**
+		 * Utility to create a new assistant message.
+		 *
+		 * @param content The content of the message.
+		 * @param name The optional name of a user for the message.
+		 */
+		static Assistant(content: string | Array<LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelDataPart>, name?: string): LanguageModelChatMessage2;
+
+		/**
+		 * The role of this message.
+		 */
+		role: LanguageModelChatMessageRole;
+
+		/**
+		 * A string or heterogeneous array of things that a message can contain as content. Some parts may be message-type
+		 * specific for some models.
+		 */
+		content: Array<LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelThinkingPart>;
+
+		/**
+		 * The optional name of a user for this message.
+		 */
+		name: string | undefined;
+
+		/**
+		 * Create a new user message.
+		 *
+		 * @param role The role of the message.
+		 * @param content The content of the message.
+		 * @param name The optional name of a user for the message.
+		 */
+		constructor(role: LanguageModelChatMessageRole, content: string | Array<LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart | LanguageModelDataPart | LanguageModelThinkingPart>, name?: string);
+	}
+
+	/**
+	 * Temporary alias for LanguageModelToolResultPart to avoid breaking changes in chat.
+	 */
+	export class LanguageModelToolResultPart2 extends LanguageModelToolResultPart { }
+
+	/**
+	 * Temporary alias for LanguageModelToolResult to avoid breaking changes in chat.
+	 */
+	export class LanguageModelToolResult2 extends LanguageModelToolResult { }
+}


### PR DESCRIPTION
## Summary

Adds native thinking support for Ollama models in VS Code Chat.

- Streams Ollama `message.thinking` as VS Code `LanguageModelThinkingPart` output.
- Preserves thinking content in assistant conversation history sent back to Ollama.
- Adds model-specific thinking effort controls only where accepted values are documented:
  - GPT-OSS: Low / Medium / High
  - DeepSeek V4 Flash and Pro: None / High / Max
  - GLM 5.2: High / Max
- Leaves the selector hidden for models whose accepted thinking values cannot be determined from Ollama metadata.
- Validates persisted configuration against the selected model before sending requests, so stale or cross-model values are omitted instead of producing unsupported requests.

## Why

Ollama already returns thinking separately from final response content, but the extension previously discarded it. VS Code now has a native thinking response part and per-model configuration UI.

Ollama exposes a generic `thinking` capability but does not expose the accepted values for each model. A universal effort selector therefore misrepresents some models—for example, GPT-OSS cannot normally disable thinking, while DeepSeek V4 and GLM 5.2 support `max`. This PR uses conservative, documented mappings and avoids guessing for unknown models.

## Validation

- Tested in a VS Code Extension Development Host with GPT-OSS, DeepSeek V4 Flash, GLM 5.2, Qwen 3.6, and Gemma 4.
- Confirmed unknown or unmapped models do not show a no-op thinking selector.
- Added focused tests for model policies, stale configuration, request translation, history conversion, and thinking-only history.
- `npm test`: 53/53 passing.
- `git diff --check`: clean.

## Attribution

Original native thinking implementation by @101arrowz. Follow-up work rebased the branch onto current `main`, added model-aware controls, request validation, and tests.
