### PR TITLE
Forward tool result images to Ollama

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -28,9 +28,11 @@ export function toOllamaMessages(messages: readonly vscode.LanguageModelChatRequ
           }
         });
       } else if (part instanceof vscode.LanguageModelToolResultPart) {
+        const result = toolResultContent(part);
         toolResults.push({
           role: 'tool',
-          content: toolResultContent(part),
+          content: result.content,
+          ...(result.images.length > 0 ? { images: result.images } : {}),
           tool_call_id: part.callId
         });
       }
@@ -75,8 +77,9 @@ function roleToOllama(role: vscode.LanguageModelChatMessageRole): string {
   return 'user';
 }
 
-function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
+function toolResultContent(part: vscode.LanguageModelToolResultPart): { content: string; images: string[] } {
   const content: string[] = [];
+  const images: string[] = [];
 
   for (const item of sanitizeToolResult(part)) {
     if (item instanceof vscode.LanguageModelTextPart) {
@@ -84,6 +87,10 @@ function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
       continue;
     }
     if (item instanceof vscode.LanguageModelDataPart) {
+      if (item.mimeType.startsWith('image/')) {
+        images.push(Buffer.from(item.data).toString('base64'));
+        continue;
+      }
       if (item.mimeType.startsWith('text/')) {
         content.push(new TextDecoder().decode(item.data));
         continue;
@@ -92,7 +99,7 @@ function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
     content.push(JSON.stringify(item));
   }
 
-  return content.join('\n');
+  return { content: content.join('\n'), images };
 }
 
 const providerOnlyToolResultMimeTypes: ReadonlySet<string> = new Set(['cache_control']);

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -90,3 +90,18 @@ test('keeps the existing fallback for unknown tool result content', () => {
     tool_call_id: 'call-3'
   }]);
 });
+
+test('forwards image data from tool results on the corresponding tool message', () => {
+  const imageBytes = Uint8Array.from([0, 1, 2, 3]);
+  const result = new LanguageModelToolResultPart('call-4', [
+    new LanguageModelTextPart('browser screenshot'),
+    new LanguageModelDataPart(imageBytes, 'image/png')
+  ]);
+
+  assert.deepEqual(toOllamaMessages([{ role: 1, content: [result] }]), [{
+    role: 'tool',
+    content: 'browser screenshot',
+    images: [Buffer.from(imageBytes).toString('base64')],
+    tool_call_id: 'call-4'
+  }]);
+});


### PR DESCRIPTION
## Summary

- forward `image/*` `LanguageModelDataPart` bytes from tool results through the Ollama message `images` field
- keep existing tool-result text, provider metadata filtering, and unknown-content fallback behavior
- add regression coverage for a tool result containing text and synthetic image bytes

## Why

VS Code's integrated browser returns screenshots as `LanguageModelDataPart` values nested inside a `LanguageModelToolResultPart`. The converter handled image parts at the top level, but nested image parts were serialized as textual metadata instead of being sent through Ollama's `images` field. As a result, vision-capable models could not inspect browser screenshots.

Fixes #9.

## Validation

- `npm test` — 17/17 tests passed
- manually verified in VS Code with the integrated browser and `kimi-k2.7-code:cloud`
