### PR TITLE
Harden tool result data parts

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -78,7 +78,7 @@ function roleToOllama(role: vscode.LanguageModelChatMessageRole): string {
 function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
   const content: string[] = [];
 
-  for (const item of sanitizeToolResult(part)) {
+  for (const item of part.content) {
     if (item instanceof vscode.LanguageModelTextPart) {
       content.push(item.value);
       continue;
@@ -86,8 +86,10 @@ function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
     if (item instanceof vscode.LanguageModelDataPart) {
       if (item.mimeType.startsWith('text/')) {
         content.push(new TextDecoder().decode(item.data));
-        continue;
+      } else if (isJsonMimeType(item.mimeType)) {
+        content.push(new TextDecoder().decode(item.data));
       }
+      continue;
     }
     content.push(JSON.stringify(item));
   }
@@ -95,16 +97,8 @@ function toolResultContent(part: vscode.LanguageModelToolResultPart): string {
   return content.join('\n');
 }
 
-const providerOnlyToolResultMimeTypes: ReadonlySet<string> = new Set(['cache_control']);
-
-/**
- * Remove provider-only metadata before tool results become model-visible text.
- * Add future control MIME types to providerOnlyToolResultMimeTypes.
- */
-function sanitizeToolResult(
-  part: vscode.LanguageModelToolResultPart
-): vscode.LanguageModelToolResultPart['content'] {
-  return part.content.filter(item =>
-    !(item instanceof vscode.LanguageModelDataPart && providerOnlyToolResultMimeTypes.has(item.mimeType))
-  );
+function isJsonMimeType(mimeType: string): boolean {
+  const normalized = mimeType.split(';', 1)[0].trim().toLowerCase();
+  return normalized === 'application/json'
+    || (normalized.startsWith('application/') && normalized.endsWith('+json'));
 }

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -55,10 +55,11 @@ try {
   Module._load = originalLoad;
 }
 
-test('omits cache control metadata from tool results', () => {
+test('omits cache control and unrecognized provider metadata from tool results', () => {
   const result = new LanguageModelToolResultPart('call-1', [
     new LanguageModelTextPart('first'),
     new LanguageModelDataPart(new TextEncoder().encode('ephemeral'), 'cache_control'),
+    new LanguageModelDataPart(new TextEncoder().encode('provider metadata'), 'application/vnd.provider.metadata'),
     new LanguageModelDataPart(new TextEncoder().encode('second'), 'text/plain')
   ]);
 
@@ -69,9 +70,10 @@ test('omits cache control metadata from tool results', () => {
   }]);
 });
 
-test('preserves an empty tool result when it only contains cache control metadata', () => {
+test('preserves an empty tool result when it only contains provider metadata', () => {
   const result = new LanguageModelToolResultPart('call-2', [
-    new LanguageModelDataPart(new TextEncoder().encode('ephemeral'), 'cache_control')
+    new LanguageModelDataPart(new TextEncoder().encode('ephemeral'), 'cache_control'),
+    new LanguageModelDataPart(new TextEncoder().encode('provider metadata'), 'application/vnd.provider.metadata')
   ]);
 
   assert.deepEqual(toOllamaMessages([{ role: 1, content: [result] }]), [{
@@ -81,12 +83,32 @@ test('preserves an empty tool result when it only contains cache control metadat
   }]);
 });
 
-test('keeps the existing fallback for unknown tool result content', () => {
-  const result = new LanguageModelToolResultPart('call-3', [{ status: 'ok' }]);
+test('preserves text, supported JSON data, and JSON-compatible tool result content', () => {
+  const result = new LanguageModelToolResultPart('call-3', [
+    new LanguageModelTextPart('first'),
+    new LanguageModelDataPart(new TextEncoder().encode('second'), 'text/plain'),
+    new LanguageModelDataPart(new TextEncoder().encode('{"status":"ok"}'), 'application/json; charset=utf-8'),
+    new LanguageModelDataPart(new TextEncoder().encode('{"vendor":true}'), 'application/vnd.example+json'),
+    { legacy: true }
+  ]);
 
   assert.deepEqual(toOllamaMessages([{ role: 1, content: [result] }]), [{
     role: 'tool',
-    content: '{"status":"ok"}',
+    content: 'first\nsecond\n{"status":"ok"}\n{"vendor":true}\n{"legacy":true}',
     tool_call_id: 'call-3'
+  }]);
+});
+
+test('preserves image data on regular chat messages', () => {
+  const imageBytes = Uint8Array.from([0, 1, 2, 3]);
+
+  assert.deepEqual(toOllamaMessages([{
+    role: 1,
+    content: [new LanguageModelDataPart(imageBytes, 'image/png')]
+  }]), [{
+    role: 'user',
+    content: '',
+    images: [Buffer.from(imageBytes).toString('base64')],
+    tool_calls: undefined
   }]);
 });


### PR DESCRIPTION
## Summary

- allowlist text and JSON `LanguageModelDataPart` values in tool results
- discard unrecognized provider-only DataParts instead of serializing their metadata
- preserve parameterized and vendor `+json` MIME types
- add regressions for hidden metadata, text, JSON, legacy JSON-compatible content, and existing image forwarding

## Why

Long Agent sessions can include hidden VS Code provider metadata such as `cache_control` in tool results. The existing conversion filtered only that exact MIME type, so other provider-only DataParts fell through to `JSON.stringify` and could reach Ollama `/api/chat`, contributing to HTTP 400 failures.

This change keeps the existing tool-result UX and recognized content while defensively dropping DataParts that the Ollama message format does not understand.

Addresses #32.

## Validation

- `npm test` — 17 tests passed
- focused converter suite — 4 tests passed
- isolated serialized request-body check confirmed provider metadata is absent while text, JSON, legacy JSON-compatible content, and image bytes are preserved
