### PR TITLE
Warn when Ollama context length is below 64K

### DIFF
--- a/src/contextLength.ts
+++ b/src/contextLength.ts
@@ -1,0 +1,82 @@
+export const minimumMachineContextLength = 64 * 1024;
+
+interface OllamaProcessModel {
+  name?: unknown;
+  model?: unknown;
+  context_length?: unknown;
+}
+
+export function machineContextLength(
+  models: readonly unknown[],
+  requestedModel: string
+): number | undefined {
+  const requestedKey = modelKey(requestedModel);
+
+  for (const candidate of models) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+
+    const model = candidate as OllamaProcessModel;
+    const matches = [model.name, model.model].some(name =>
+      typeof name === 'string' && modelKey(name) === requestedKey
+    );
+    if (matches && isPositiveInteger(model.context_length)) {
+      return model.context_length;
+    }
+  }
+
+  return undefined;
+}
+
+export async function waitForMachineContextLength(
+  listModels: () => Promise<readonly unknown[]>,
+  requestedModel: string,
+  isRequestSettled: () => boolean,
+  waitForNextCheck: () => Promise<boolean>
+): Promise<number | undefined> {
+  while (true) {
+    const settledBeforeCheck = isRequestSettled();
+    const contextLength = machineContextLength(await listModels(), requestedModel);
+    if (contextLength !== undefined) {
+      return contextLength;
+    }
+
+    if (settledBeforeCheck) {
+      return undefined;
+    }
+    if (isRequestSettled()) {
+      // The request settled while /api/ps was in flight. Check once more now
+      // that Ollama has finished loading the model.
+      continue;
+    }
+    if (!await waitForNextCheck()) {
+      return undefined;
+    }
+  }
+}
+
+export function isMachineContextTooSmall(contextLength: number): boolean {
+  return contextLength < minimumMachineContextLength;
+}
+
+export function formatContextLength(contextLength: number): string {
+  return contextLength % 1024 === 0
+    ? `${contextLength / 1024}K`
+    : contextLength.toLocaleString('en-US');
+}
+
+function modelKey(name: string): string {
+  const normalized = name.trim().toLowerCase();
+  return normalized.endsWith(':latest')
+    ? normalized.slice(0, -':latest'.length)
+    : normalized;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/contextLength.ts
+++ b/src/contextLength.ts
@@ -38,22 +38,35 @@ export async function waitForMachineContextLength(
   while (true) {
     const settledBeforeCheck = isRequestSettled();
     const contextLength = machineContextLength(await listModels(), requestedModel);
-    if (contextLength !== undefined) {
+    if (settledBeforeCheck) {
       return contextLength;
     }
 
-    if (settledBeforeCheck) {
-      return undefined;
-    }
     if (isRequestSettled()) {
-      // The request settled while /api/ps was in flight. Check once more now
-      // that Ollama has finished loading the model.
+      // Ignore a result from a lookup that began before the request settled.
+      // Check once more now that Ollama has finished loading the model.
       continue;
     }
     if (!await waitForNextCheck()) {
       return undefined;
     }
   }
+}
+
+export async function waitForMachineContextCheckBeforeStreaming(
+  check: Promise<void>,
+  waitForTimeout: () => Promise<void>,
+  cancelCheck: () => void
+): Promise<void> {
+  let checkFinished = false;
+  await Promise.race([
+    check.finally(() => { checkFinished = true; }),
+    waitForTimeout().then(() => {
+      if (!checkFinished) {
+        cancelCheck();
+      }
+    })
+  ]);
 }
 
 export function isMachineContextTooSmall(contextLength: number): boolean {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -22,6 +22,12 @@ import {
   recommendedReplacement
 } from './recommendations';
 import { createChatFetch } from './chatFetch';
+import {
+  formatContextLength,
+  isMachineContextTooSmall,
+  minimumMachineContextLength,
+  waitForMachineContextLength
+} from './contextLength';
 
 interface OllamaProviderConfiguration {
   url: string;
@@ -33,11 +39,14 @@ interface OllamaLanguageModel extends vscode.LanguageModelChatInformation {
   model: string;
   url: string;
   headers: Record<string, string>;
+  local: boolean;
   recommendedReplacement?: string;
 }
 
 const defaultOllamaURL = 'http://127.0.0.1:11434';
 const recommendationTimeoutMS = 2000;
+const initialContextCheckDelayMS = 25;
+const maxContextCheckDelayMS = 500;
 const fallbackContextWindow = 32768;
 const defaultMaxOutputTokens = 4096;
 const defaultCharsPerToken = 4;
@@ -121,6 +130,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
   private readonly changeEmitter = new vscode.EventEmitter<void>();
   private readonly tokenCounts = new CalibratedTokenEstimator();
   private readonly outdatedModelWarnings = new OutdatedModelWarningTracker();
+  private readonly machineContextWarnings = new Set<string>();
   readonly onDidChangeLanguageModelChatInformation = this.changeEmitter.event;
 
   constructor(private readonly output?: vscode.OutputChannel) {}
@@ -223,15 +233,30 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     try {
       let promptTokenCount: number | undefined;
       let completionTokenCount: number | undefined;
-      const stream = await ollama.chat({
+      let chatRequestSettled = false;
+      const streamRequest = ollama.chat({
         model: model.model,
         messages: ollamaMessages,
         stream: true,
         tools: tools.length > 0 ? tools : undefined,
         options: options.modelOptions ? { ...options.modelOptions } : undefined
       } as ChatRequest & { stream: true });
+      void streamRequest.then(
+        () => { chatRequestSettled = true; },
+        () => { chatRequestSettled = true; }
+      );
+      const contextLengthCheck = this.checkMachineContextLength(
+        ollama,
+        model,
+        () => chatRequestSettled,
+        token
+      );
+
+      const stream = await streamRequest;
       const streamDisposable = token.onCancellationRequested(() => stream.abort());
       disposables.push(streamDisposable);
+      // Hold buffered chunks until the context warning has been requested.
+      await contextLengthCheck;
 
       for await (const chunk of stream as AsyncIterable<ChatResponse>) {
         const response = chunk as OllamaChatResponse;
@@ -301,6 +326,71 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     }
 
     return this.userFacingError(error);
+  }
+
+  private async checkMachineContextLength(
+    ollama: Ollama,
+    model: OllamaLanguageModel,
+    isChatRequestSettled: () => boolean,
+    token: vscode.CancellationToken
+  ): Promise<void> {
+    if (!model.local) {
+      return;
+    }
+
+    let contextLength: number | undefined;
+    let nextDelayMS = initialContextCheckDelayMS;
+    try {
+      contextLength = await waitForMachineContextLength(
+        () => ollama.ps().then(processes => processes.models),
+        model.model,
+        isChatRequestSettled,
+        async () => {
+          const completed = await waitForContextCheck(nextDelayMS, token);
+          nextDelayMS = Math.min(nextDelayMS * 2, maxContextCheckDelayMS);
+          return completed;
+        }
+      );
+    } catch (error) {
+      this.output?.appendLine(`Could not check Ollama's allocated context length: ${formatError(error)}`);
+      return;
+    }
+
+    if (contextLength === undefined) {
+      return;
+    }
+
+    const warningKey = model.url;
+    if (!isMachineContextTooSmall(contextLength)) {
+      this.machineContextWarnings.delete(warningKey);
+      return;
+    }
+    if (this.machineContextWarnings.has(warningKey)) {
+      return;
+    }
+    this.machineContextWarnings.add(warningKey);
+
+    const allocated = formatContextLength(contextLength);
+    const minimum = formatContextLength(minimumMachineContextLength);
+    this.output?.appendLine(
+      `Ollama allocated a ${allocated} context window for ${model.model}; at least ${minimum} is recommended.`
+    );
+
+    const learnHow = 'Learn how';
+    void vscode.window.showWarningMessage(
+      `Ollama is using a ${allocated} context window. Set it to at least ${minimum} in Ollama Settings, reload this window, then resend your prompt.`,
+      learnHow
+    ).then(selected => {
+      if (selected === learnHow) {
+        return vscode.env.openExternal(vscode.Uri.parse('https://docs.ollama.com/context-length'));
+      }
+      return undefined;
+    }, error => {
+      this.output?.appendLine(`Could not show context length guidance: ${formatError(error)}`);
+      return undefined;
+    }).then(undefined, error => {
+      this.output?.appendLine(`Could not open context length guidance: ${formatError(error)}`);
+    });
   }
 
   private userFacingError(error: unknown): Error {
@@ -386,6 +476,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       model: name,
       url: configuration.url,
       headers: configuration.headers,
+      local: !isRemoteModel(model) && !isCloudModel(name),
       recommendedReplacement: replacement
     };
   }
@@ -456,6 +547,34 @@ async function showWarningMessageUntilCancelled<T extends string>(
       selected => finish({ kind: 'selection', selected }),
       error => finish({ kind: 'error', error })
     );
+  });
+}
+
+function waitForContextCheck(
+  delayMS: number,
+  token: vscode.CancellationToken
+): Promise<boolean> {
+  if (token.isCancellationRequested) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise(resolve => {
+    let settled = false;
+    let cancellation: vscode.Disposable | undefined;
+    const timer = setTimeout(() => finish(true), delayMS);
+    const finish = (completed: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      cancellation?.dispose();
+      resolve(completed);
+    };
+    cancellation = token.onCancellationRequested(() => finish(false));
+    if (settled) {
+      cancellation.dispose();
+    }
   });
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -26,6 +26,7 @@ import {
   formatContextLength,
   isMachineContextTooSmall,
   minimumMachineContextLength,
+  waitForMachineContextCheckBeforeStreaming,
   waitForMachineContextLength
 } from './contextLength';
 
@@ -47,6 +48,7 @@ const defaultOllamaURL = 'http://127.0.0.1:11434';
 const recommendationTimeoutMS = 2000;
 const initialContextCheckDelayMS = 25;
 const maxContextCheckDelayMS = 500;
+const machineContextCheckTimeoutMS = 1000;
 const fallbackContextWindow = 32768;
 const defaultMaxOutputTokens = 4096;
 const defaultCharsPerToken = 4;
@@ -229,6 +231,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     const tools = toOllamaTools(options.tools);
     this.output?.appendLine(`Sending chat request to ${model.model} at ${model.url}.`);
     let requestSucceeded = false;
+    let machineContextSource: vscode.CancellationTokenSource | undefined;
 
     try {
       let promptTokenCount: number | undefined;
@@ -245,18 +248,40 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
         () => { chatRequestSettled = true; },
         () => { chatRequestSettled = true; }
       );
-      const contextLengthCheck = this.checkMachineContextLength(
-        ollama,
-        model,
-        () => chatRequestSettled,
-        token
-      );
+      let contextLengthCheck: Promise<void> | undefined;
+      if (model.local) {
+        machineContextSource = new vscode.CancellationTokenSource();
+        const cancelMachineContextCheck = token.onCancellationRequested(() => machineContextSource?.cancel());
+        disposables.push(machineContextSource, cancelMachineContextCheck);
+        if (token.isCancellationRequested) {
+          machineContextSource.cancel();
+        }
+        const contextOllama = new Ollama({
+          host: model.url,
+          headers: model.headers,
+          fetch: createFetch(machineContextSource.token, disposables)
+        });
+        contextLengthCheck = this.checkMachineContextLength(
+          contextOllama,
+          model,
+          () => chatRequestSettled,
+          machineContextSource.token
+        );
+      }
 
       const stream = await streamRequest;
       const streamDisposable = token.onCancellationRequested(() => stream.abort());
       disposables.push(streamDisposable);
-      // Hold buffered chunks until the context warning has been requested.
-      await contextLengthCheck;
+      if (contextLengthCheck && machineContextSource) {
+        const contextSource = machineContextSource;
+        // Hold buffered chunks briefly while confirming the loaded model's context.
+        await waitForMachineContextCheckBeforeStreaming(
+          contextLengthCheck,
+          () => waitForContextCheck(machineContextCheckTimeoutMS, contextSource.token).then(() => undefined),
+          () => contextSource.cancel()
+        );
+        contextSource.cancel();
+      }
 
       for await (const chunk of stream as AsyncIterable<ChatResponse>) {
         const response = chunk as OllamaChatResponse;
@@ -291,6 +316,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     } catch (error) {
       throw await this.handleChatError(model, error);
     } finally {
+      machineContextSource?.cancel();
       this.outdatedModelWarnings.finishRequest(warningRequest, requestSucceeded);
       disposeAll(disposables);
     }
@@ -352,6 +378,9 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
         }
       );
     } catch (error) {
+      if (token.isCancellationRequested) {
+        return;
+      }
       this.output?.appendLine(`Could not check Ollama's allocated context length: ${formatError(error)}`);
       return;
     }

--- a/test/contextLength.test.js
+++ b/test/contextLength.test.js
@@ -1,0 +1,104 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  formatContextLength,
+  isMachineContextTooSmall,
+  machineContextLength,
+  minimumMachineContextLength,
+  waitForMachineContextLength
+} = require('../out/contextLength');
+
+test('warns only below the 64K machine context threshold', () => {
+  assert.equal(minimumMachineContextLength, 65536);
+  assert.equal(isMachineContextTooSmall(65535), true);
+  assert.equal(isMachineContextTooSmall(65536), false);
+  assert.equal(isMachineContextTooSmall(131072), false);
+});
+
+test('reads the allocated context from the matching running model', () => {
+  assert.equal(machineContextLength([
+    { name: 'other:latest', context_length: 131072 },
+    {
+      name: 'gemma3:latest',
+      context_length: 32768,
+      model_info: { 'gemma3.context_length': 131072 }
+    }
+  ], 'gemma3'), 32768);
+});
+
+test('matches latest aliases and ignores invalid process context values', () => {
+  assert.equal(machineContextLength([
+    { model: 'qwen3.5:latest', context_length: 65536 }
+  ], 'QWEN3.5'), 65536);
+
+  for (const contextLength of [undefined, 0, -1, 1.5, '32768']) {
+    assert.equal(machineContextLength([
+      { name: 'qwen3.5', context_length: contextLength }
+    ], 'qwen3.5'), undefined);
+  }
+});
+
+test('formats binary context sizes for the warning', () => {
+  assert.equal(formatContextLength(32768), '32K');
+  assert.equal(formatContextLength(65536), '64K');
+  assert.equal(formatContextLength(64000), '64,000');
+});
+
+test('polls for the machine context while the chat request is loading', async () => {
+  let checks = 0;
+  let waits = 0;
+  const contextLength = await waitForMachineContextLength(
+    async () => ++checks === 1
+      ? []
+      : [{ name: 'gemma3', context_length: 32768 }],
+    'gemma3',
+    () => false,
+    async () => {
+      waits++;
+      return true;
+    }
+  );
+
+  assert.equal(contextLength, 32768);
+  assert.equal(checks, 2);
+  assert.equal(waits, 1);
+});
+
+test('checks once more when the chat response arrives during a process lookup', async () => {
+  let requestSettled = false;
+  let checks = 0;
+  const contextLength = await waitForMachineContextLength(
+    async () => {
+      checks++;
+      if (checks === 1) {
+        requestSettled = true;
+        return [];
+      }
+      return [{ model: 'gemma3:latest', context_length: 65536 }];
+    },
+    'gemma3',
+    () => requestSettled,
+    async () => {
+      assert.fail('should retry immediately after the response arrives');
+    }
+  );
+
+  assert.equal(contextLength, 65536);
+  assert.equal(checks, 2);
+});
+
+test('stops polling when the request has settled without a local process', async () => {
+  let waits = 0;
+  const contextLength = await waitForMachineContextLength(
+    async () => [],
+    'gemma3',
+    () => true,
+    async () => {
+      waits++;
+      return true;
+    }
+  );
+
+  assert.equal(contextLength, undefined);
+  assert.equal(waits, 0);
+});

--- a/test/contextLength.test.js
+++ b/test/contextLength.test.js
@@ -39,6 +39,22 @@ test('matches latest aliases and ignores invalid process context values', () => 
   }
 });
 
+test('does not treat model metadata as the runtime context allocation', () => {
+  assert.equal(machineContextLength([
+    {
+      name: 'gemma3:latest',
+      details: { context_length: 32768 },
+      model_info: { 'gemma3.context_length': 131072 }
+    }
+  ], 'gemma3'), undefined);
+});
+
+test('does not use the context allocation from a different running model', () => {
+  assert.equal(machineContextLength([
+    { name: 'qwen3.5:latest', context_length: 32768 }
+  ], 'gemma3'), undefined);
+});
+
 test('formats binary context sizes for the warning', () => {
   assert.equal(formatContextLength(32768), '32K');
   assert.equal(formatContextLength(65536), '64K');
@@ -129,6 +145,27 @@ test('stops polling when the request has settled without a local process', async
 
   assert.equal(contextLength, undefined);
   assert.equal(waits, 0);
+});
+
+test('stops polling when the next context check is cancelled', async () => {
+  let checks = 0;
+  let waits = 0;
+  const contextLength = await waitForMachineContextLength(
+    async () => {
+      checks++;
+      return [];
+    },
+    'gemma3',
+    () => false,
+    async () => {
+      waits++;
+      return false;
+    }
+  );
+
+  assert.equal(contextLength, undefined);
+  assert.equal(checks, 1);
+  assert.equal(waits, 1);
 });
 
 test('releases a ready chat stream when the machine context check does not respond', async () => {

--- a/test/contextLength.test.js
+++ b/test/contextLength.test.js
@@ -5,6 +5,7 @@ const {
   isMachineContextTooSmall,
   machineContextLength,
   minimumMachineContextLength,
+  waitForMachineContextCheckBeforeStreaming,
   waitForMachineContextLength
 } = require('../out/contextLength');
 
@@ -45,6 +46,7 @@ test('formats binary context sizes for the warning', () => {
 });
 
 test('polls for the machine context while the chat request is loading', async () => {
+  let requestSettled = false;
   let checks = 0;
   let waits = 0;
   const contextLength = await waitForMachineContextLength(
@@ -52,9 +54,10 @@ test('polls for the machine context while the chat request is loading', async ()
       ? []
       : [{ name: 'gemma3', context_length: 32768 }],
     'gemma3',
-    () => false,
+    () => requestSettled,
     async () => {
       waits++;
+      requestSettled = true;
       return true;
     }
   );
@@ -64,6 +67,31 @@ test('polls for the machine context while the chat request is loading', async ()
   assert.equal(waits, 1);
 });
 
+for (const [before, after] of [
+  [32768, 65536],
+  [65536, 32768]
+]) {
+  test(`confirms a ${formatContextLength(before)} runner changed to ${formatContextLength(after)} after chat readiness`, async () => {
+    let requestSettled = false;
+    let checks = 0;
+    const contextLength = await waitForMachineContextLength(
+      async () => {
+        checks++;
+        return [{ name: 'gemma3', context_length: checks === 1 ? before : after }];
+      },
+      'gemma3',
+      () => requestSettled,
+      async () => {
+        requestSettled = true;
+        return true;
+      }
+    );
+
+    assert.equal(contextLength, after);
+    assert.equal(checks, 2);
+  });
+}
+
 test('checks once more when the chat response arrives during a process lookup', async () => {
   let requestSettled = false;
   let checks = 0;
@@ -72,7 +100,7 @@ test('checks once more when the chat response arrives during a process lookup', 
       checks++;
       if (checks === 1) {
         requestSettled = true;
-        return [];
+        return [{ model: 'gemma3:latest', context_length: 32768 }];
       }
       return [{ model: 'gemma3:latest', context_length: 65536 }];
     },
@@ -101,4 +129,33 @@ test('stops polling when the request has settled without a local process', async
 
   assert.equal(contextLength, undefined);
   assert.equal(waits, 0);
+});
+
+test('releases a ready chat stream when the machine context check does not respond', async () => {
+  let cancelled = false;
+  const neverSettles = new Promise(() => {});
+
+  await waitForMachineContextCheckBeforeStreaming(
+    neverSettles,
+    async () => {},
+    () => { cancelled = true; }
+  );
+
+  assert.equal(cancelled, true);
+});
+
+test('does not time out a machine context check that finishes first', async () => {
+  let releaseTimeout;
+  let cancelled = false;
+  const timeout = new Promise(resolve => { releaseTimeout = resolve; });
+
+  await waitForMachineContextCheckBeforeStreaming(
+    Promise.resolve(),
+    () => timeout,
+    () => { cancelled = true; }
+  );
+  releaseTimeout();
+  await Promise.resolve();
+
+  assert.equal(cancelled, false);
 });


### PR DESCRIPTION
## Summary

- inspect the runtime context allocated to local models through `/api/ps`
- warn once per Ollama endpoint when the allocated context is below 64K
- tell users to update Ollama Settings, reload VS Code, and resend their prompt
- start the chat request and poll for the loaded model in parallel, while holding response chunks until the warning is requested
- skip the machine-context check for cloud models

The current user-facing warning is:
``` text
Ollama is using a 32K context window. Set it to at least 64K in Ollama Settings, reload this window, then resend your prompt.
```
** The 32K value changes to whatever Ollama reports for the running model. There is also a Learn how button linking to the context-length documentation.

## Why

Model metadata reports a model's maximum context window, not the context allocated by the user's Ollama server. The runtime allocation is only available after a local model begins loading. Without this check, coding and agent requests can run with an undersized machine context and behave unreliably without explaining why.

## User impact

Users with less than 64K allocated receive one actionable warning before the response becomes visible. Users at 64K or above, and users of cloud models, see no warning.

## Testing

- `npm test` (27 tests passed)
