### PR TITLE
Diagnose loaded model context allocation

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,223 @@
+import {
+  formatContextLength,
+  isMachineContextTooSmall,
+  minimumMachineContextLength
+} from './contextLength';
+
+interface LoadedModel {
+  name: string;
+  contextLength?: number;
+}
+
+type ModelMetadataLookup = (model: string) => Promise<unknown>;
+
+interface OllamaModelList {
+  models?: readonly unknown[];
+}
+
+export interface OllamaDiagnosticsClient {
+  list(): Promise<OllamaModelList>;
+  ps(): Promise<OllamaModelList>;
+  show(request: { model: string }): Promise<unknown>;
+}
+
+export interface OllamaModelInspection {
+  availableModels?: string[];
+  availableModelsError?: unknown;
+  loadedModelLines?: string[];
+  loadedModelsError?: unknown;
+}
+
+export function ollamaDiagnosticsClientOptions(
+  host: string,
+  configuredHeaders: Readonly<Record<string, unknown>>,
+  request: typeof fetch
+): { host: string; headers: Record<string, string>; fetch: typeof fetch } {
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(configuredHeaders)) {
+    if (typeof value === 'string') {
+      headers[name] = value;
+    }
+  }
+  return { host, headers, fetch: request };
+}
+
+export async function inspectOllamaModels(
+  client: OllamaDiagnosticsClient
+): Promise<OllamaModelInspection> {
+  const [availableResult, loadedResult] = await Promise.allSettled([
+    client.list(),
+    client.ps()
+  ]);
+  const inspection: OllamaModelInspection = {};
+  const availableModels = availableResult.status === 'fulfilled'
+    ? availableResult.value.models ?? []
+    : [];
+
+  if (availableResult.status === 'fulfilled') {
+    inspection.availableModels = modelNames(availableModels);
+  } else {
+    inspection.availableModelsError = availableResult.reason;
+  }
+
+  if (loadedResult.status === 'fulfilled') {
+    inspection.loadedModelLines = await loadedModelContextDiagnosticLines(
+      loadedResult.value.models ?? [],
+      availableModels,
+      model => client.show({ model })
+    );
+  } else {
+    inspection.loadedModelsError = loadedResult.reason;
+  }
+
+  return inspection;
+}
+
+export async function loadedModelContextDiagnosticLines(
+  models: readonly unknown[],
+  availableModels: readonly unknown[],
+  getModelMetadata: ModelMetadataLookup
+): Promise<string[]> {
+  const loadedModels = models
+    .map(loadedLocalModel)
+    .filter((model): model is LoadedModel => model !== undefined);
+
+  if (loadedModels.length === 0) {
+    return [
+      'No local models are currently loaded. Send a prompt to a local Ollama model, then rerun `Ollama: Diagnose Models`.'
+    ];
+  }
+
+  const modelLines = await Promise.all(loadedModels.map(async model => {
+    let maximum = maximumSupportedContextLength(findModelMetadata(availableModels, model.name));
+    if (maximum === undefined) {
+      try {
+        maximum = maximumSupportedContextLength(await getModelMetadata(model.name));
+      } catch {
+        // Maximum context metadata is optional; the runtime allocation remains useful.
+      }
+    }
+    return loadedModelContextLine(model, maximum);
+  }));
+
+  return [
+    `Ollama reports ${loadedModels.length} loaded local model(s):`,
+    ...modelLines
+  ];
+}
+
+function findModelMetadata(models: readonly unknown[], requestedModel: string): unknown {
+  const requestedKey = modelKey(requestedModel);
+  return models.find(candidate => isRecord(candidate) && [candidate.name, candidate.model].some(name =>
+    typeof name === 'string' && modelKey(name) === requestedKey
+  ));
+}
+
+function modelNames(models: readonly unknown[]): string[] {
+  return models.flatMap(model => {
+    if (!isRecord(model) || typeof model.name !== 'string' || model.name.length === 0) {
+      return [];
+    }
+    return [model.name];
+  });
+}
+
+export function maximumSupportedContextLength(metadata: unknown): number | undefined {
+  if (!isRecord(metadata)) {
+    return undefined;
+  }
+
+  for (const value of [
+    positiveInteger(metadata.max_context_length),
+    positiveIntegerField(metadata.details, 'max_context_length'),
+    positiveInteger(metadata.context_length),
+    positiveIntegerField(metadata.details, 'context_length'),
+    modelInfoContextLength(metadata.model_info, 'max_context_length'),
+    modelInfoContextLength(metadata.model_info, 'context_length')
+  ]) {
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function loadedLocalModel(candidate: unknown): LoadedModel | undefined {
+  if (!isRecord(candidate)) {
+    return undefined;
+  }
+
+  const name = [candidate.name, candidate.model]
+    .find(value => typeof value === 'string' && value.length > 0);
+  if (typeof name !== 'string' || isRemoteModel(candidate, name)) {
+    return undefined;
+  }
+
+  return {
+    name,
+    contextLength: positiveInteger(candidate.context_length)
+  };
+}
+
+function loadedModelContextLine(model: LoadedModel, maximum: number | undefined): string {
+  const allocation = model.contextLength === undefined
+    ? 'unavailable'
+    : formatContextLength(model.contextLength);
+  const maximumContext = maximum === undefined
+    ? 'unavailable'
+    : formatContextLength(maximum);
+  const warningSuffix = model.contextLength !== undefined && isMachineContextTooSmall(model.contextLength)
+    ? `; WARNING: runtime allocation is below the recommended ${formatContextLength(minimumMachineContextLength)}`
+    : '';
+
+  return `- ${model.name}: runtime context allocation: ${allocation}; maximum supported context: ${maximumContext}${warningSuffix}`;
+}
+
+function isRemoteModel(model: Record<string, unknown>, name: string): boolean {
+  if (typeof model.remote_host === 'string' && model.remote_host.length > 0) {
+    return true;
+  }
+  const tag = name.split(':').at(-1)?.toLowerCase() ?? '';
+  return tag === 'cloud' || tag.endsWith('-cloud');
+}
+
+function modelKey(name: string): string {
+  const normalized = name.trim().toLowerCase();
+  return normalized.endsWith(':latest')
+    ? normalized.slice(0, -':latest'.length)
+    : normalized;
+}
+
+function modelInfoContextLength(
+  modelInfo: unknown,
+  expectedKey: 'context_length' | 'max_context_length'
+): number | undefined {
+  const entries = modelInfo instanceof Map
+    ? modelInfo.entries()
+    : isRecord(modelInfo)
+      ? Object.entries(modelInfo)
+      : [];
+
+  for (const [key, value] of entries) {
+    const contextLength = positiveInteger(value);
+    if ((key === expectedKey || key.endsWith(`.${expectedKey}`)) && contextLength !== undefined) {
+      return contextLength;
+    }
+  }
+  return undefined;
+}
+
+function positiveIntegerField(value: unknown, key: string): number | undefined {
+  return isRecord(value) ? positiveInteger(value[key]) : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -15,6 +15,53 @@ interface OllamaModelList {
   models?: readonly unknown[];
 }
 
+export interface OllamaDiagnosticsConfiguration {
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+}
+
+export type OllamaDiagnosticsConfigurationSource =
+  | 'used-provider-group'
+  | 'resolved-provider-group'
+  | 'workspace-settings';
+
+export interface OllamaDiagnosticsConfigurationSelection {
+  configuration: OllamaDiagnosticsConfiguration;
+  source: OllamaDiagnosticsConfigurationSource;
+}
+
+export class OllamaDiagnosticsConfigurationTracker {
+  private lastResolvedConfiguration: OllamaDiagnosticsConfiguration | undefined;
+  private lastUsedConfiguration: OllamaDiagnosticsConfiguration | undefined;
+
+  recordResolved(configuration: OllamaDiagnosticsConfiguration): void {
+    this.lastResolvedConfiguration = copyConfiguration(configuration);
+  }
+
+  recordUsed(configuration: OllamaDiagnosticsConfiguration): void {
+    this.lastUsedConfiguration = copyConfiguration(configuration);
+  }
+
+  select(workspaceConfiguration: OllamaDiagnosticsConfiguration): OllamaDiagnosticsConfigurationSelection {
+    if (this.lastUsedConfiguration) {
+      return {
+        configuration: copyConfiguration(this.lastUsedConfiguration),
+        source: 'used-provider-group'
+      };
+    }
+    if (this.lastResolvedConfiguration) {
+      return {
+        configuration: copyConfiguration(this.lastResolvedConfiguration),
+        source: 'resolved-provider-group'
+      };
+    }
+    return {
+      configuration: copyConfiguration(workspaceConfiguration),
+      source: 'workspace-settings'
+    };
+  }
+}
+
 export interface OllamaDiagnosticsClient {
   list(): Promise<OllamaModelList>;
   ps(): Promise<OllamaModelList>;
@@ -216,6 +263,13 @@ function positiveInteger(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
     ? value
     : undefined;
+}
+
+function copyConfiguration(configuration: OllamaDiagnosticsConfiguration): OllamaDiagnosticsConfiguration {
+  return {
+    url: configuration.url,
+    headers: { ...configuration.headers }
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Ollama } from 'ollama';
 import { OllamaLanguageModelProvider, createFetch, disposeAll } from './provider';
+import { inspectOllamaModels, ollamaDiagnosticsClientOptions } from './diagnostics';
 
 const defaultOllamaURL = 'http://127.0.0.1:11434';
 const ollamaVendor = 'ollama-models';
@@ -35,51 +36,53 @@ async function diagnoseModels(output: vscode.OutputChannel) {
   const ollamaVSCodeModels = allVSCodeModels.filter(model => model.vendor === ollamaVendor);
   output.appendLine(`VS Code returned ${ollamaVSCodeModels.length} Ollama language model(s).`);
 
-  const directModels = await listDirectOllamaModels(output);
-  if (directModels.length > 0) {
-    output.appendLine(`Direct Ollama API returned ${directModels.length} model(s).`);
-    for (const model of directModels.slice(0, 20)) {
-      output.appendLine(`- ${model}`);
-    }
-    if (directModels.length > 20) {
-      output.appendLine(`... ${directModels.length - 20} more`);
-    }
-  }
+  await inspectDirectOllamaModels(output);
 
   output.appendLine('--- End Diagnostics ---');
 }
 
-async function listDirectOllamaModels(output: vscode.OutputChannel): Promise<string[]> {
+async function inspectDirectOllamaModels(output: vscode.OutputChannel): Promise<void> {
   const settings = vscode.workspace.getConfiguration('ollama');
   const endpoint = settings.get<string>('endpoint', defaultOllamaURL) || defaultOllamaURL;
   const source = new vscode.CancellationTokenSource();
   const disposables: vscode.Disposable[] = [source];
-  const ollama = new Ollama({
-    host: endpoint,
-    headers: getConfiguredHeaders(settings),
-    fetch: createFetch(source.token, disposables)
-  });
+  const ollama = new Ollama(ollamaDiagnosticsClientOptions(
+    endpoint,
+    settings.get<Record<string, unknown>>('headers', {}),
+    createFetch(source.token, disposables)
+  ));
   const timer = setTimeout(() => source.cancel(), 5000);
   try {
-    return ((await ollama.list()).models ?? [])
-      .filter(model => typeof model.name === 'string' && model.name.length > 0)
-      .map(model => model.name);
-  } catch (error) {
-    output.appendLine(`Direct Ollama API failed at ${endpoint}: ${error instanceof Error ? error.message : String(error)}`);
-    return [];
+    const inspection = await inspectOllamaModels(ollama);
+
+    if (inspection.availableModels !== undefined) {
+      const availableModelNames = inspection.availableModels;
+      if (availableModelNames.length > 0) {
+        output.appendLine(`Direct Ollama API returned ${availableModelNames.length} model(s).`);
+        for (const model of availableModelNames.slice(0, 20)) {
+          output.appendLine(`- ${model}`);
+        }
+        if (availableModelNames.length > 20) {
+          output.appendLine(`... ${availableModelNames.length - 20} more`);
+        }
+      }
+    } else {
+      output.appendLine(`Direct Ollama API failed at ${endpoint}: ${formatError(inspection.availableModelsError)}`);
+    }
+
+    if (inspection.loadedModelLines !== undefined) {
+      for (const line of inspection.loadedModelLines) {
+        output.appendLine(line);
+      }
+    } else {
+      output.appendLine(`Could not inspect loaded Ollama models at ${endpoint}: ${formatError(inspection.loadedModelsError)}`);
+    }
   } finally {
     clearTimeout(timer);
     disposeAll(disposables);
   }
 }
 
-function getConfiguredHeaders(settings: vscode.WorkspaceConfiguration): Record<string, string> {
-  const configured = settings.get<Record<string, unknown>>('headers', {});
-  const headers: Record<string, string> = {};
-  for (const [name, value] of Object.entries(configured)) {
-    if (typeof value === 'string') {
-      headers[name] = value;
-    }
-  }
-  return headers;
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,11 @@
 import * as vscode from 'vscode';
 import { Ollama } from 'ollama';
 import { OllamaLanguageModelProvider, createFetch, disposeAll } from './provider';
-import { inspectOllamaModels, ollamaDiagnosticsClientOptions } from './diagnostics';
+import {
+  inspectOllamaModels,
+  ollamaDiagnosticsClientOptions,
+  type OllamaDiagnosticsConfigurationSource
+} from './diagnostics';
 
 const defaultOllamaURL = 'http://127.0.0.1:11434';
 const ollamaVendor = 'ollama-models';
@@ -17,13 +21,13 @@ export function activate(context: vscode.ExtensionContext) {
     provider,
     vscode.lm.registerLanguageModelChatProvider(ollamaVendor, provider),
     vscode.commands.registerCommand('ollama.refreshModels', () => provider.refresh()),
-    vscode.commands.registerCommand('ollama.diagnoseModels', () => diagnoseModels(output))
+    vscode.commands.registerCommand('ollama.diagnoseModels', () => diagnoseModels(output, provider))
   );
 }
 
 export function deactivate() {}
 
-async function diagnoseModels(output: vscode.OutputChannel) {
+async function diagnoseModels(output: vscode.OutputChannel, provider: OllamaLanguageModelProvider) {
   output.show(true);
   output.appendLine('--- Diagnostics ---');
 
@@ -36,19 +40,30 @@ async function diagnoseModels(output: vscode.OutputChannel) {
   const ollamaVSCodeModels = allVSCodeModels.filter(model => model.vendor === ollamaVendor);
   output.appendLine(`VS Code returned ${ollamaVSCodeModels.length} Ollama language model(s).`);
 
-  await inspectDirectOllamaModels(output);
+  await inspectDirectOllamaModels(output, provider);
 
   output.appendLine('--- End Diagnostics ---');
 }
 
-async function inspectDirectOllamaModels(output: vscode.OutputChannel): Promise<void> {
+async function inspectDirectOllamaModels(
+  output: vscode.OutputChannel,
+  provider: OllamaLanguageModelProvider
+): Promise<void> {
   const settings = vscode.workspace.getConfiguration('ollama');
-  const endpoint = settings.get<string>('endpoint', defaultOllamaURL) || defaultOllamaURL;
+  const workspaceEndpoint = settings.get<string>('endpoint', defaultOllamaURL) || defaultOllamaURL;
+  const selected = provider.selectDiagnosticsConfiguration({
+    url: workspaceEndpoint,
+    headers: getConfiguredHeaders(settings)
+  });
+  const { url: endpoint, headers } = selected.configuration;
+  output.appendLine(
+    `Direct Ollama API is inspecting ${configurationSourceLabel(selected.source)} at ${endpoint}.`
+  );
   const source = new vscode.CancellationTokenSource();
   const disposables: vscode.Disposable[] = [source];
   const ollama = new Ollama(ollamaDiagnosticsClientOptions(
     endpoint,
-    settings.get<Record<string, unknown>>('headers', {}),
+    headers,
     createFetch(source.token, disposables)
   ));
   const timer = setTimeout(() => source.cancel(), 5000);
@@ -80,6 +95,28 @@ async function inspectDirectOllamaModels(output: vscode.OutputChannel): Promise<
   } finally {
     clearTimeout(timer);
     disposeAll(disposables);
+  }
+}
+
+function getConfiguredHeaders(settings: vscode.WorkspaceConfiguration): Record<string, string> {
+  const configured = settings.get<Record<string, unknown>>('headers', {});
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(configured)) {
+    if (typeof value === 'string') {
+      headers[name] = value;
+    }
+  }
+  return headers;
+}
+
+function configurationSourceLabel(source: OllamaDiagnosticsConfigurationSource): string {
+  switch (source) {
+    case 'used-provider-group':
+      return 'the most recently used provider group';
+    case 'resolved-provider-group':
+      return 'the most recently resolved provider group';
+    case 'workspace-settings':
+      return 'workspace settings';
   }
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -29,6 +29,11 @@ import {
   waitForMachineContextCheckBeforeStreaming,
   waitForMachineContextLength
 } from './contextLength';
+import {
+  OllamaDiagnosticsConfigurationTracker,
+  type OllamaDiagnosticsConfiguration,
+  type OllamaDiagnosticsConfigurationSelection
+} from './diagnostics';
 
 interface OllamaProviderConfiguration {
   url: string;
@@ -133,6 +138,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
   private readonly tokenCounts = new CalibratedTokenEstimator();
   private readonly outdatedModelWarnings = new OutdatedModelWarningTracker();
   private readonly machineContextWarnings = new Set<string>();
+  private readonly diagnosticsConfigurations = new OllamaDiagnosticsConfigurationTracker();
   readonly onDidChangeLanguageModelChatInformation = this.changeEmitter.event;
 
   constructor(private readonly output?: vscode.OutputChannel) {}
@@ -146,11 +152,18 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     this.changeEmitter.dispose();
   }
 
+  selectDiagnosticsConfiguration(
+    workspaceConfiguration: OllamaDiagnosticsConfiguration
+  ): OllamaDiagnosticsConfigurationSelection {
+    return this.diagnosticsConfigurations.select(workspaceConfiguration);
+  }
+
   async provideLanguageModelChatInformation(
     options: vscode.PrepareLanguageModelChatModelOptions,
     token: vscode.CancellationToken
   ): Promise<OllamaLanguageModel[]> {
     const configuration = getConfiguration(options);
+    this.diagnosticsConfigurations.recordResolved(configuration);
     const disposables: vscode.Disposable[] = [];
     const request = createFetch(token, disposables);
     const ollama = new Ollama({
@@ -229,6 +242,7 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       fetch: createFetch(token, disposables, chatFetch.fetch)
     });
     const tools = toOllamaTools(options.tools);
+    this.diagnosticsConfigurations.recordUsed(model);
     this.output?.appendLine(`Sending chat request to ${model.model} at ${model.url}.`);
     let requestSucceeded = false;
     let machineContextSource: vscode.CancellationTokenSource | undefined;

--- a/test/diagnostics.test.js
+++ b/test/diagnostics.test.js
@@ -1,0 +1,148 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  inspectOllamaModels,
+  loadedModelContextDiagnosticLines,
+  maximumSupportedContextLength,
+  ollamaDiagnosticsClientOptions
+} = require('../out/diagnostics');
+
+test('preserves endpoint, string headers, and cancellation-aware fetch in client options', () => {
+  const request = async () => new Response();
+  const options = ollamaDiagnosticsClientOptions(
+    'https://ollama.example.test',
+    {
+      Authorization: 'Bearer secret',
+      'X-Ollama-Count': 2,
+      'X-Ollama-Disabled': false
+    },
+    request
+  );
+
+  assert.equal(options.host, 'https://ollama.example.test');
+  assert.deepEqual(options.headers, { Authorization: 'Bearer secret' });
+  assert.equal(options.fetch, request);
+});
+
+test('queries loaded models and reuses tags metadata through the diagnostics client', async () => {
+  const calls = [];
+  const inspection = await inspectOllamaModels({
+    async list() {
+      calls.push('list');
+      return {
+        models: [{ name: 'gemma3:latest', details: { context_length: 131072 } }]
+      };
+    },
+    async ps() {
+      calls.push('ps');
+      return {
+        models: [{ name: 'gemma3:latest', context_length: 32768 }]
+      };
+    },
+    async show() {
+      assert.fail('tag metadata should avoid an additional lookup');
+    }
+  });
+
+  assert.deepEqual(calls, ['list', 'ps']);
+  assert.deepEqual(inspection.availableModels, ['gemma3:latest']);
+  assert.deepEqual(inspection.loadedModelLines, [
+    'Ollama reports 1 loaded local model(s):',
+    '- gemma3:latest: runtime context allocation: 32K; maximum supported context: 128K; WARNING: runtime allocation is below the recommended 64K'
+  ]);
+});
+
+test('keeps available model diagnostics when the loaded-model request fails', async () => {
+  const psError = new Error('ps unavailable');
+  const inspection = await inspectOllamaModels({
+    async list() {
+      return { models: [{ name: 'gemma3:latest' }] };
+    },
+    async ps() {
+      throw psError;
+    },
+    async show() {
+      assert.fail('a failed process lookup should not request model metadata');
+    }
+  });
+
+  assert.deepEqual(inspection.availableModels, ['gemma3:latest']);
+  assert.equal(inspection.loadedModelLines, undefined);
+  assert.equal(inspection.loadedModelsError, psError);
+});
+
+test('uses show metadata when tags fail but loaded models are available', async () => {
+  const listError = new Error('tags unavailable');
+  let shownModel;
+  const inspection = await inspectOllamaModels({
+    async list() {
+      throw listError;
+    },
+    async ps() {
+      return {
+        models: [{ model: 'qwen3.5:latest', context_length: 65536 }]
+      };
+    },
+    async show({ model }) {
+      shownModel = model;
+      return { model_info: { 'qwen3.context_length': 262144 } };
+    }
+  });
+
+  assert.equal(inspection.availableModels, undefined);
+  assert.equal(inspection.availableModelsError, listError);
+  assert.equal(shownModel, 'qwen3.5:latest');
+  assert.deepEqual(inspection.loadedModelLines, [
+    'Ollama reports 1 loaded local model(s):',
+    '- qwen3.5:latest: runtime context allocation: 64K; maximum supported context: 256K'
+  ]);
+});
+
+test('flags a loaded model whose runtime context allocation is below 64K', async () => {
+  const lines = await loadedModelContextDiagnosticLines([
+    { name: 'gemma3:latest', context_length: 32768 }
+  ], [
+    { name: 'gemma3:latest', details: { context_length: 131072 } }
+  ], async () => {
+    assert.fail('tag metadata should avoid an additional lookup');
+  });
+
+  assert.deepEqual(lines, [
+    'Ollama reports 1 loaded local model(s):',
+    '- gemma3:latest: runtime context allocation: 32K; maximum supported context: 128K; WARNING: runtime allocation is below the recommended 64K'
+  ]);
+});
+
+test('reports a sufficient loaded runtime context allocation without a warning', async () => {
+  const lines = await loadedModelContextDiagnosticLines([
+    {
+      model: 'qwen3.5:latest',
+      context_length: 65536
+    }
+  ], [], async model => {
+    assert.equal(model, 'qwen3.5:latest');
+    return { max_context_length: 262144 };
+  });
+
+  assert.deepEqual(lines, [
+    'Ollama reports 1 loaded local model(s):',
+    '- qwen3.5:latest: runtime context allocation: 64K; maximum supported context: 256K'
+  ]);
+});
+
+test('explains how to populate diagnostics when no local model is loaded', async () => {
+  const lines = await loadedModelContextDiagnosticLines([], [], async () => {
+    assert.fail('an empty process list should not request model metadata');
+  });
+
+  assert.deepEqual(lines, [
+    'No local models are currently loaded. Send a prompt to a local Ollama model, then rerun `Ollama: Diagnose Models`.'
+  ]);
+});
+
+test('reads maximum context only from model metadata supplied separately from the runtime process', () => {
+  assert.equal(maximumSupportedContextLength({ context_length: 131072 }), 131072);
+  assert.equal(maximumSupportedContextLength({
+    model_info: { 'gemma3.context_length': 131072 }
+  }), 131072);
+});

--- a/test/diagnostics.test.js
+++ b/test/diagnostics.test.js
@@ -4,8 +4,56 @@ const {
   inspectOllamaModels,
   loadedModelContextDiagnosticLines,
   maximumSupportedContextLength,
+  OllamaDiagnosticsConfigurationTracker,
   ollamaDiagnosticsClientOptions
 } = require('../out/diagnostics');
+
+test('uses the most recently resolved provider group when the workspace endpoint differs', () => {
+  const tracker = new OllamaDiagnosticsConfigurationTracker();
+  const workspaceConfiguration = {
+    url: 'https://workspace.example.test',
+    headers: { Authorization: 'Bearer workspace' }
+  };
+  tracker.recordResolved({
+    url: 'https://previous-provider.example.test',
+    headers: { Authorization: 'Bearer previous-provider' }
+  });
+  tracker.recordResolved({
+    url: 'https://provider.example.test',
+    headers: { Authorization: 'Bearer provider' }
+  });
+
+  const selected = tracker.select(workspaceConfiguration);
+
+  assert.equal(selected.source, 'resolved-provider-group');
+  assert.deepEqual(selected.configuration, {
+    url: 'https://provider.example.test',
+    headers: { Authorization: 'Bearer provider' }
+  });
+});
+
+test('prefers the most recently used provider group for diagnostics', () => {
+  const tracker = new OllamaDiagnosticsConfigurationTracker();
+  tracker.recordResolved({
+    url: 'https://resolved.example.test',
+    headers: { 'X-Ollama-Group': 'resolved' }
+  });
+  tracker.recordUsed({
+    url: 'https://used.example.test',
+    headers: { 'X-Ollama-Group': 'used' }
+  });
+
+  const selected = tracker.select({
+    url: 'https://workspace.example.test',
+    headers: {}
+  });
+
+  assert.equal(selected.source, 'used-provider-group');
+  assert.deepEqual(selected.configuration, {
+    url: 'https://used.example.test',
+    headers: { 'X-Ollama-Group': 'used' }
+  });
+});
 
 test('preserves endpoint, string headers, and cancellation-aware fetch in client options', () => {
   const request = async () => new Response();


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #48. Merge #48 first, then retarget or rebase this branch onto `main`.

## Summary

- extend `Ollama: Diagnose Models` to inspect currently loaded local models through `/api/ps`
- report Ollama's runtime context allocation separately from the model's maximum supported context
- use `/api/tags` context metadata first and fall back to `/api/show` when needed
- flag runtime allocations below the existing 64K recommendation
- explain that users should send a prompt and rerun diagnostics when no local model is loaded
- preserve the configured endpoint, request headers, cancellation timeout, and partial-error reporting

## Why

Model discovery metadata describes what a model supports, but it does not show the context Ollama actually allocated when loading that model. The runtime allocation is available from `/api/ps` and can be much smaller than the supported maximum.

Adding the runtime value to the existing diagnostics command makes undersized allocations visible without introducing another command or conflating model capability with server configuration.

## User impact

Users can run `Ollama: Diagnose Models` to see, for each loaded local model:

- the current runtime context allocation
- the maximum supported context when reliable metadata is available
- a clear warning when the allocation is below 64K

If no local model is loaded, the output explains how to populate the diagnostic.

## Testing

- `npm test` — 35 tests passed
- focused coverage for low, sufficient, and no-loaded-model behavior
- client-boundary coverage for endpoint, headers, cancellation-aware fetch, `/api/ps`, partial failures, and `/api/show` fallback
