### PR TITLE
Make inference timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ If Ollama models do not appear:
 4. Run `Ollama: Diagnose Models` and check the `Ollama` output channel.
 
 If a cloud model asks you to sign in, run `ollama signin`.
+
+If a slow local model takes more than 10 minutes to begin responding, increase
+**Ollama: Inference Timeout Minutes** in VS Code Settings. The timeout only
+affects inference requests made by this extension. Cancelling Chat still stops
+the request immediately.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,13 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "ollama.inferenceTimeoutMinutes": {
+            "type": "integer",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 60,
+            "description": "Maximum time, in minutes, to wait for Ollama to begin an inference response. Cancelling Chat still stops the request immediately."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
             "default": 10,
             "minimum": 1,
             "maximum": 60,
-            "description": "Maximum time, in minutes, to wait for Ollama to begin an inference response. Cancelling Chat still stops the request immediately."
+            "description": "Maximum time to wait for Ollama to begin an inference response. Enter a whole number from 1 to 60 minutes. Cancelling Chat still stops the request immediately."
           }
         }
       }

--- a/src/chatFetch.ts
+++ b/src/chatFetch.ts
@@ -11,8 +11,6 @@ interface ChatFetch {
   dispose(): void;
 }
 
-const CHAT_HEADERS_TIMEOUT = 10 * 60 * 1000;
-
 export function trustedCACertificates(
   loadCertificates: typeof getCACertificates = getCACertificates
 ): string[] {
@@ -23,7 +21,7 @@ export function trustedCACertificates(
 }
 
 export function createChatFetch(
-  headersTimeout = CHAT_HEADERS_TIMEOUT,
+  headersTimeout: number,
   loadCertificates: typeof getCACertificates = getCACertificates
 ): ChatFetch {
   const dispatcher = new Agent({

--- a/src/inferenceTimeout.ts
+++ b/src/inferenceTimeout.ts
@@ -1,0 +1,14 @@
+export const defaultInferenceTimeoutMinutes = 10;
+export const minimumInferenceTimeoutMinutes = 1;
+export const maximumInferenceTimeoutMinutes = 60;
+
+export function inferenceTimeoutMilliseconds(value: unknown): number {
+  const minutes = typeof value === 'number'
+    && Number.isInteger(value)
+    && value >= minimumInferenceTimeoutMinutes
+    && value <= maximumInferenceTimeoutMinutes
+    ? value
+    : defaultInferenceTimeoutMinutes;
+
+  return minutes * 60 * 1000;
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -34,6 +34,7 @@ import {
   type OllamaDiagnosticsConfiguration,
   type OllamaDiagnosticsConfigurationSelection
 } from './diagnostics';
+import { inferenceTimeoutMilliseconds } from './inferenceTimeout';
 
 interface OllamaProviderConfiguration {
   url: string;
@@ -234,7 +235,10 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     }
 
     const disposables: vscode.Disposable[] = [];
-    const chatFetch = createChatFetch();
+    const inferenceTimeout = inferenceTimeoutMilliseconds(
+      vscode.workspace.getConfiguration('ollama').get('inferenceTimeoutMinutes')
+    );
+    const chatFetch = createChatFetch(inferenceTimeout);
     disposables.push(chatFetch);
     const ollama = new Ollama({
       host: model.url,

--- a/test/chatFetch.test.js
+++ b/test/chatFetch.test.js
@@ -99,7 +99,7 @@ test('waits for delayed response headers within the chat timeout', async () => {
       response.end('{"done":true}\n');
     }, 75);
   }, async url => {
-    const transport = createChatFetch();
+    const transport = createChatFetch(1000);
     try {
       const response = await transport.fetch(`${url}/api/chat`, {
         method: 'POST',
@@ -195,7 +195,7 @@ test('links VS Code cancellation to the chat request', async () => {
   }, async url => {
     const source = cancellationTokenSource();
     const disposables = [];
-    const transport = createChatFetch();
+    const transport = createChatFetch(1000);
     const request = createFetch(source.token, disposables, transport.fetch);
 
     try {

--- a/test/inferenceTimeout.test.js
+++ b/test/inferenceTimeout.test.js
@@ -1,0 +1,31 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  defaultInferenceTimeoutMinutes,
+  inferenceTimeoutMilliseconds,
+  maximumInferenceTimeoutMinutes,
+  minimumInferenceTimeoutMinutes
+} = require('../out/inferenceTimeout');
+
+test('uses the configured inference timeout in minutes', () => {
+  assert.equal(inferenceTimeoutMilliseconds(30), 30 * 60 * 1000);
+  assert.equal(inferenceTimeoutMilliseconds(minimumInferenceTimeoutMinutes), 60 * 1000);
+  assert.equal(inferenceTimeoutMilliseconds(maximumInferenceTimeoutMinutes), 60 * 60 * 1000);
+});
+
+test('falls back to the finite default for invalid inference timeouts', () => {
+  const fallback = defaultInferenceTimeoutMinutes * 60 * 1000;
+  for (const value of [
+    undefined,
+    null,
+    '30',
+    0,
+    -1,
+    1.5,
+    maximumInferenceTimeoutMinutes + 1,
+    NaN,
+    Infinity
+  ]) {
+    assert.equal(inferenceTimeoutMilliseconds(value), fallback, String(value));
+  }
+});


### PR DESCRIPTION
## Summary

Closes #53.

Slow local models can take more than 10 minutes to produce their first response
headers or token. The extension currently closes those requests at a hard-coded
10-minute Undici `headersTimeout`, even when Ollama is still working normally.

This change:

- adds an Ollama extension setting, `ollama.inferenceTimeoutMinutes`
- keeps the existing 10-minute default and accepts finite values from 1 to 60 minutes
- applies the setting only to the dedicated chat response-header timeout
- preserves the existing streamed-body timeout and VS Code cancellation behavior
- falls back safely to 10 minutes for invalid runtime values
- documents the setting and adds validation coverage

The setting affects only inference requests made by the Ollama VS Code extension;
it does not change Ollama server or global VS Code networking behavior.

## Verification

- `npm test` — 46 tests passed
- `git diff --check`
