### PR TITLE
feat: add Open WebUI Ollama API Proxy support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,6 +20,20 @@ Configure the endpoint and optional request headers in VS Code settings:
 }
 ```
 
+### Open WebUI Proxy Mode
+
+To route requests through an Open WebUI instance using its Ollama API Proxy, enable:
+
+```json
+{
+  "ollama.endpoint": "http://127.0.0.1:3000",
+  "ollama.useOpenWebUIProxy": true,
+  "ollama.openWebUIApiKey": "your-api-key-here"
+}
+```
+
+When enabled, the extension automatically prepends `/ollama` to your endpoint URL and injects a Bearer token into every request. See the README for more details.
+
 VS Code can also pass provider configuration through `chatLanguageModels.json`:
 
 ```json
@@ -29,7 +43,9 @@ VS Code can also pass provider configuration through `chatLanguageModels.json`:
     "name": "Ollama",
     "url": "http://127.0.0.1:11434",
     "models": ["qwen3.6"],
-    "headers": {}
+    "headers": {},
+    "useOpenWebUIProxy": false,
+    "openWebUIApiKey": ""
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -56,9 +56,17 @@ Download the latest `.vsix` release from the [Releases](https://github.com/tpedr
 
 > **Note:** If you previously installed the Ollama extension from the Marketplace, the manual installation will override it. To revert, uninstall via the Extensions view or run `code --uninstall-extension ollama`.
 
+### Verifying Installation
+
+After installing, confirm the extension is active:
+
+1. Open the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
+2. Search for **Ollama** — you should see it listed with a green **Enable** or gear icon indicating it's installed.
+3. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and type `Ollama: Refresh Models`. If the command appears, the extension is active.
+
 ## Get started
 
-1. Install the Ollama extension — see **Manual Installation** below.
+1. Install the Ollama extension — see **Manual Installation** above.
 2. Start Ollama *or* your Open WebUI instance.
 3. Open Chat in VS Code.
 4. Open the model picker at the bottom of the chat input.
@@ -86,8 +94,8 @@ Open WebUI proxy mode requires two settings:
 
 1. Open **Settings** (`Ctrl+,` / `Cmd+,`).
 2. Search for **Ollama**.
-3. Check the box **"Use Open WebUI Ollama API Proxy"**.
-4. Enter your Open WebUI API key in the **"Open WebUI API Key"** field.
+3. Check the box **"Use Open WebUI Ollama API Proxy"** (or enable **ollama.useOpenWebUIProxy**).
+4. Enter your Open WebUI API key in the **"Open WebUI API Key"** field (**ollama.openWebUIApiKey**).
    - Get your key from Open WebUI → **Settings** → **Account** → **API Keys**.
 
 #### Option B — `settings.json`

--- a/README.md
+++ b/README.md
@@ -26,9 +26,39 @@ ollama signin
 
 Local models do not require sign-in. Run `ollama signin` to use cloud models.
 
+## Manual Installation
+
+Download the latest `.vsix` release from the [Releases](https://github.com/tpedretti/ollama-vscode-openwebui/releases) page, then install it using one of these methods:
+
+#### Method 1 — VS Code UI (recommended)
+
+1. Open VS Code.
+2. Open the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
+3. Click the **...** (More Actions) menu in the top-right corner of the Extensions panel.
+4. Select **Install from VSIX...** and navigate to the downloaded `.vsix` file.
+5. Once installed, reload VS Code when prompted.
+
+#### Method 2 — Command Line
+
+1. Open a terminal and navigate to the folder containing the downloaded `.vsix` file.
+2. Run:
+   ```sh
+   code --install-extension ./ollama-0.0.5.vsix
+   ```
+   (Replace `ollama-0.0.5.vsix` with the actual filename.)
+3. Reload VS Code when prompted, or run `code --reload-window`.
+
+#### Method 3 — Drag and Drop
+
+1. Open VS Code and go to the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
+2. Drag the downloaded `.vsix` file from your file manager into the Extensions panel.
+3. VS Code will automatically install the extension. Reload when prompted.
+
+> **Note:** If you previously installed the Ollama extension from the Marketplace, the manual installation will override it. To revert, uninstall via the Extensions view or run `code --uninstall-extension ollama`.
+
 ## Get started
 
-1. Install the Ollama extension from the VS Code Marketplace (or install this fork's `.vsix`).
+1. Install the Ollama extension — see **Manual Installation** below.
 2. Start Ollama *or* your Open WebUI instance.
 3. Open Chat in VS Code.
 4. Open the model picker at the bottom of the chat input.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Ollama for VS Code
+# Ollama for VS Code (with Open WebUI Proxy Support)
 
 Use Ollama models in VS Code Chat.
 
 The Ollama extension adds models from your running Ollama server to the VS Code
-model picker.
+model picker. This fork adds first-class support for routing requests through an **Open WebUI** instance using its [Ollama API Proxy](https://docs.openwebui.com/reference/api-endpoints/#ollama-api-proxy-support).
 
 ## Requirements
 
 - Visual Studio Code 1.120 or newer.
-- Ollama installed and running.
+- Ollama installed and running, *or* an Open WebUI instance configured with an Ollama backend.
 - At least one local or cloud model available in Ollama.
 
 Ollama 0.17.6 or newer is recommended for cloud model sign-in and richer model metadata. Older Ollama versions may still work for local models.
@@ -28,13 +28,76 @@ Local models do not require sign-in. Run `ollama signin` to use cloud models.
 
 ## Get started
 
-1. Install the Ollama extension from the VS Code Marketplace.
-2. Start Ollama.
+1. Install the Ollama extension from the VS Code Marketplace (or install this fork's `.vsix`).
+2. Start Ollama *or* your Open WebUI instance.
 3. Open Chat in VS Code.
 4. Open the model picker at the bottom of the chat input.
 5. Choose a model from the `Ollama` section.
 
 The extension discovers models from `http://127.0.0.1:11434` by default.
+
+## Open WebUI Proxy Mode
+
+Open WebUI provides a transparent passthrough to the Ollama API via its `/ollama/` proxy prefix. When this mode is enabled, all requests are routed through your Open WebUI instance instead of hitting Ollama directly. This gives you access to Open WebUI's authentication, filters (inlet/outlet), rate limiting, and other middleware features.
+
+### How it works
+
+| | Direct Ollama | Via Open WebUI Proxy |
+|---|---|---|
+| **List models** | `GET http://localhost:11434/api/tags` | `GET http://localhost:3000/ollama/api/tags` |
+| **Chat** | `POST http://localhost:11434/api/chat` | `POST http://localhost:3000/ollama/api/chat` |
+| **Auth header** | *(none)* | `Authorization: Bearer <API_KEY>` |
+
+### Enabling Open WebUI Proxy Mode
+
+Open WebUI proxy mode requires two settings:
+
+#### Option A — VS Code Settings UI (recommended)
+
+1. Open **Settings** (`Ctrl+,` / `Cmd+,`).
+2. Search for **Ollama**.
+3. Check the box **"Use Open WebUI Ollama API Proxy"**.
+4. Enter your Open WebUI API key in the **"Open WebUI API Key"** field.
+   - Get your key from Open WebUI → **Settings** → **Account** → **API Keys**.
+
+#### Option B — `settings.json`
+
+```json
+{
+  "ollama.endpoint": "http://127.0.0.1:3000",
+  "ollama.useOpenWebUIProxy": true,
+  "ollama.openWebUIApiKey": "your-api-key-here"
+}
+```
+
+> **Note:** When proxy mode is enabled, the extension automatically prepends `/ollama` to your endpoint URL (e.g., `http://127.0.0.1:3000` becomes `http://127.0.0.1:3000/ollama`) and injects the Bearer token into every request. You do **not** need to include `/ollama` manually in your endpoint.
+
+#### Option C — `chatLanguageModels.json` (per-model override)
+
+```json
+[
+  {
+    "vendor": "ollama-models",
+    "name": "Ollama",
+    "url": "http://127.0.0.1:3000",
+    "useOpenWebUIProxy": true,
+    "openWebUIApiKey": "your-api-key-here",
+    "models": ["qwen3.6"],
+    "headers": {}
+  }
+]
+```
+
+Provider configuration from VS Code takes precedence over workspace settings.
+
+### Getting your Open WebUI API Key
+
+1. Open Open WebUI in your browser.
+2. Navigate to **Settings** → **Account**.
+3. Find the **API Keys** section and generate or copy your key.
+4. Paste it into the extension setting above.
+
+---
 
 ## Commands
 
@@ -44,15 +107,21 @@ The extension adds these commands to the Command Palette:
 - `Ollama: Diagnose Models`: print model discovery information to the Ollama
   output channel for troubleshooting.
 
-Use `Diagnose Models` if models are available in Ollama but do not appear in the VS Code model picker.
+Use `Diagnose Models` if models are available in Ollama but do not appear in the VS Code model picker. The diagnostics output now also reports whether Open WebUI proxy mode is active and your API key status (masked for security).
 
 ## Troubleshooting
 
 If Ollama models do not appear:
 
-1. Make sure Ollama is running.
-2. Run `ollama list` and confirm models are available.
+1. Make sure Ollama (or Open WebUI) is running.
+2. Run `ollama list` (or check Open WebUI's model list) and confirm models are available.
 3. Run `Ollama: Refresh Models` from the Command Palette.
 4. Run `Ollama: Diagnose Models` and check the `Ollama` output channel.
+
+If using Open WebUI proxy mode:
+
+- Ensure your **endpoint** points to Open WebUI (e.g., `http://127.0.0.1:3000`), not directly to Ollama.
+- Verify your **API key** is valid and has permission to access models.
+- Check that Open WebUI has an Ollama backend configured.
 
 If a cloud model asks you to sign in, run `ollama signin`.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Ollama for VS Code
+# Ollama for VS Code (with Open WebUI Proxy Support)
 
 Use Ollama models in VS Code Chat.
 
 The Ollama extension adds models from your running Ollama server to the VS Code
-model picker.
+model picker. This fork adds first-class support for routing requests through an **Open WebUI** instance using its [Ollama API Proxy](https://docs.openwebui.com/reference/api-endpoints/#ollama-api-proxy-support).
 
 ## Requirements
 
 - Visual Studio Code 1.127 or newer. Earlier versions do not reliably cancel
   requests from language model providers.
-- Ollama installed and running.
+- Ollama installed and running, *or* an Open WebUI instance configured with an Ollama backend.
 - At least one local or cloud model available in Ollama.
 
 Ollama 0.17.6 or newer is recommended for cloud model sign-in and richer model metadata. Older Ollama versions may still work for local models.
@@ -27,15 +27,116 @@ ollama signin
 
 Local models do not require sign-in. Run `ollama signin` to use cloud models.
 
+## Manual Installation
+
+Download the latest `.vsix` release from the [Releases](https://github.com/tpedretti/ollama-vscode-openwebui/releases) page, then install it using one of these methods:
+
+#### Method 1 — VS Code UI (recommended)
+
+1. Open VS Code.
+2. Open the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
+3. Click the **...** (More Actions) menu in the top-right corner of the Extensions panel.
+4. Select **Install from VSIX...** and navigate to the downloaded `.vsix` file.
+5. Once installed, reload VS Code when prompted.
+
+#### Method 2 — Command Line
+
+1. Open a terminal and navigate to the folder containing the downloaded `.vsix` file.
+2. Run:
+   ```sh
+   code --install-extension ./ollama-0.0.5.vsix
+   ```
+   (Replace `ollama-0.0.5.vsix` with the actual filename.)
+3. Reload VS Code when prompted, or run `code --reload-window`.
+
+#### Method 3 — Drag and Drop
+
+1. Open VS Code and go to the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
+2. Drag the downloaded `.vsix` file from your file manager into the Extensions panel.
+3. VS Code will automatically install the extension. Reload when prompted.
+
+> **Note:** If you previously installed the Ollama extension from the Marketplace, the manual installation will override it. To revert, uninstall via the Extensions view or run `code --uninstall-extension ollama`.
+
+### Verifying Installation
+
+After installing, confirm the extension is active:
+
+1. Open the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
+2. Search for **Ollama** — you should see it listed with a green **Enable** or gear icon indicating it's installed.
+3. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and type `Ollama: Refresh Models`. If the command appears, the extension is active.
+
 ## Get started
 
-1. Install the Ollama extension from the VS Code Marketplace.
-2. Start Ollama.
+1. Install the Ollama extension — see **Manual Installation** above.
+2. Start Ollama *or* your Open WebUI instance.
 3. Open Chat in VS Code.
 4. Open the model picker at the bottom of the chat input.
 5. Choose a model from the `Ollama` section.
 
 The extension discovers models from `http://127.0.0.1:11434` by default.
+
+## Open WebUI Proxy Mode
+
+Open WebUI provides a transparent passthrough to the Ollama API via its `/ollama/` proxy prefix. When this mode is enabled, all requests are routed through your Open WebUI instance instead of hitting Ollama directly. This gives you access to Open WebUI's authentication, filters (inlet/outlet), rate limiting, and other middleware features.
+
+### How it works
+
+| | Direct Ollama | Via Open WebUI Proxy |
+|---|---|---|
+| **List models** | `GET http://localhost:11434/api/tags` | `GET http://localhost:3000/ollama/api/tags` |
+| **Chat** | `POST http://localhost:11434/api/chat` | `POST http://localhost:3000/ollama/api/chat` |
+| **Auth header** | *(none)* | `Authorization: Bearer <API_KEY>` |
+
+### Enabling Open WebUI Proxy Mode
+
+Open WebUI proxy mode requires two settings:
+
+#### Option A — VS Code Settings UI (recommended)
+
+1. Open **Settings** (`Ctrl+,` / `Cmd+,`).
+2. Search for **Ollama**.
+3. Check the box **"Use Open WebUI Ollama API Proxy"** (or enable **ollama.useOpenWebUIProxy**).
+4. Enter your Open WebUI API key in the **"Open WebUI API Key"** field (**ollama.openWebUIApiKey**).
+   - Get your key from Open WebUI → **Settings** → **Account** → **API Keys**.
+
+#### Option B — `settings.json`
+
+```json
+{
+  "ollama.endpoint": "http://127.0.0.1:3000",
+  "ollama.useOpenWebUIProxy": true,
+  "ollama.openWebUIApiKey": "your-api-key-here"
+}
+```
+
+> **Note:** When proxy mode is enabled, the extension automatically prepends `/ollama` to your endpoint URL (e.g., `http://127.0.0.1:3000` becomes `http://127.0.0.1:3000/ollama`) and injects the Bearer token into every request. You do **not** need to include `/ollama` manually in your endpoint.
+
+#### Option C — `chatLanguageModels.json` (per-model override)
+
+```json
+[
+  {
+    "vendor": "ollama-models",
+    "name": "Ollama",
+    "url": "http://127.0.0.1:3000",
+    "useOpenWebUIProxy": true,
+    "openWebUIApiKey": "your-api-key-here",
+    "models": ["qwen3.6"],
+    "headers": {}
+  }
+]
+```
+
+Provider configuration from VS Code takes precedence over workspace settings.
+
+### Getting your Open WebUI API Key
+
+1. Open Open WebUI in your browser.
+2. Navigate to **Settings** → **Account**.
+3. Find the **API Keys** section and generate or copy your key.
+4. Paste it into the extension setting above.
+
+---
 
 ## Commands
 
@@ -45,15 +146,21 @@ The extension adds these commands to the Command Palette:
 - `Ollama: Diagnose Models`: print model discovery information to the Ollama
   output channel for troubleshooting.
 
-Use `Diagnose Models` if models are available in Ollama but do not appear in the VS Code model picker.
+Use `Diagnose Models` if models are available in Ollama but do not appear in the VS Code model picker. The diagnostics output now also reports whether Open WebUI proxy mode is active and your API key status (masked for security).
 
 ## Troubleshooting
 
 If Ollama models do not appear:
 
-1. Make sure Ollama is running.
-2. Run `ollama list` and confirm models are available.
+1. Make sure Ollama (or Open WebUI) is running.
+2. Run `ollama list` (or check Open WebUI's model list) and confirm models are available.
 3. Run `Ollama: Refresh Models` from the Command Palette.
 4. Run `Ollama: Diagnose Models` and check the `Ollama` output channel.
+
+If using Open WebUI proxy mode:
+
+- Ensure your **endpoint** points to Open WebUI (e.g., `http://127.0.0.1:3000`), not directly to Ollama.
+- Verify your **API key** is valid and has permission to access models.
+- Check that Open WebUI has an Ollama backend configured.
 
 If a cloud model asks you to sign in, run `ollama signin`.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # Ollama for VS Code (with Open WebUI Proxy Support)
-# Ollama for VS Code (with Open WebUI Proxy Support)
 
 Use Ollama models in VS Code Chat.
 
-The Ollama extension adds models from your running Ollama server to the VS Code
-model picker. This fork adds first-class support for routing requests through an **Open WebUI** instance using its [Ollama API Proxy](https://docs.openwebui.com/reference/api-endpoints/#ollama-api-proxy-support).
-model picker. This fork adds first-class support for routing requests through an **Open WebUI** instance using its [Ollama API Proxy](https://docs.openwebui.com/reference/api-endpoints/#ollama-api-proxy-support).
+The Ollama extension adds models from your running Ollama server to the VS Code model picker. This fork adds first-class support for routing requests through an **Open WebUI** instance using its [Ollama API Proxy](https://docs.openwebui.com/reference/api-endpoints/#ollama-api-proxy-support).
 
 ## Requirements
 
-- Visual Studio Code 1.127 or newer. Earlier versions do not reliably cancel
-  requests from language model providers.
+- Visual Studio Code 1.127 or newer. Earlier versions do not reliably cancel requests from language model providers.
 - Ollama installed and running, *or* an Open WebUI instance configured with an Ollama backend.
 - At least one local or cloud model available in Ollama.
 
@@ -28,44 +24,6 @@ ollama signin
 ```
 
 Local models do not require sign-in. Run `ollama signin` to use cloud models.
-
-## Manual Installation
-
-Download the latest `.vsix` release from the [Releases](https://github.com/tpedretti/ollama-vscode-openwebui/releases) page, then install it using one of these methods:
-
-#### Method 1 — VS Code UI (recommended)
-
-1. Open VS Code.
-2. Open the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
-3. Click the **...** (More Actions) menu in the top-right corner of the Extensions panel.
-4. Select **Install from VSIX...** and navigate to the downloaded `.vsix` file.
-5. Once installed, reload VS Code when prompted.
-
-#### Method 2 — Command Line
-
-1. Open a terminal and navigate to the folder containing the downloaded `.vsix` file.
-2. Run:
-   ```sh
-   code --install-extension ./ollama-0.0.5.vsix
-   ```
-   (Replace `ollama-0.0.5.vsix` with the actual filename.)
-3. Reload VS Code when prompted, or run `code --reload-window`.
-
-#### Method 3 — Drag and Drop
-
-1. Open VS Code and go to the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
-2. Drag the downloaded `.vsix` file from your file manager into the Extensions panel.
-3. VS Code will automatically install the extension. Reload when prompted.
-
-> **Note:** If you previously installed the Ollama extension from the Marketplace, the manual installation will override it. To revert, uninstall via the Extensions view or run `code --uninstall-extension ollama`.
-
-### Verifying Installation
-
-After installing, confirm the extension is active:
-
-1. Open the **Extensions** view (`Ctrl+Shift+X` / `Cmd+Shift+X`).
-2. Search for **Ollama** — you should see it listed with a green **Enable** or gear icon indicating it's installed.
-3. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and type `Ollama: Refresh Models`. If the command appears, the extension is active.
 
 ## Manual Installation
 
@@ -180,69 +138,6 @@ Provider configuration from VS Code takes precedence over workspace settings.
 
 ---
 
-## Open WebUI Proxy Mode
-
-Open WebUI provides a transparent passthrough to the Ollama API via its `/ollama/` proxy prefix. When this mode is enabled, all requests are routed through your Open WebUI instance instead of hitting Ollama directly. This gives you access to Open WebUI's authentication, filters (inlet/outlet), rate limiting, and other middleware features.
-
-### How it works
-
-| | Direct Ollama | Via Open WebUI Proxy |
-|---|---|---|
-| **List models** | `GET http://localhost:11434/api/tags` | `GET http://localhost:3000/ollama/api/tags` |
-| **Chat** | `POST http://localhost:11434/api/chat` | `POST http://localhost:3000/ollama/api/chat` |
-| **Auth header** | *(none)* | `Authorization: Bearer <API_KEY>` |
-
-### Enabling Open WebUI Proxy Mode
-
-Open WebUI proxy mode requires two settings:
-
-#### Option A — VS Code Settings UI (recommended)
-
-1. Open **Settings** (`Ctrl+,` / `Cmd+,`).
-2. Search for **Ollama**.
-3. Check the box **"Use Open WebUI Ollama API Proxy"** (or enable **ollama.useOpenWebUIProxy**).
-4. Enter your Open WebUI API key in the **"Open WebUI API Key"** field (**ollama.openWebUIApiKey**).
-   - Get your key from Open WebUI → **Settings** → **Account** → **API Keys**.
-
-#### Option B — `settings.json`
-
-```json
-{
-  "ollama.endpoint": "http://127.0.0.1:3000",
-  "ollama.useOpenWebUIProxy": true,
-  "ollama.openWebUIApiKey": "your-api-key-here"
-}
-```
-
-> **Note:** When proxy mode is enabled, the extension automatically prepends `/ollama` to your endpoint URL (e.g., `http://127.0.0.1:3000` becomes `http://127.0.0.1:3000/ollama`) and injects the Bearer token into every request. You do **not** need to include `/ollama` manually in your endpoint.
-
-#### Option C — `chatLanguageModels.json` (per-model override)
-
-```json
-[
-  {
-    "vendor": "ollama-models",
-    "name": "Ollama",
-    "url": "http://127.0.0.1:3000",
-    "useOpenWebUIProxy": true,
-    "openWebUIApiKey": "your-api-key-here",
-    "models": ["qwen3.6"],
-    "headers": {}
-  }
-]
-```
-
-Provider configuration from VS Code takes precedence over workspace settings.
-
-### Getting your Open WebUI API Key
-
-1. Open Open WebUI in your browser.
-2. Navigate to **Settings** → **Account**.
-3. Find the **API Keys** section and generate or copy your key.
-4. Paste it into the extension setting above.
-
----
-
 ## Commands
 
 The extension adds these commands to the Command Palette:
@@ -251,7 +146,6 @@ The extension adds these commands to the Command Palette:
 - `Ollama: Diagnose Models`: print model discovery information to the Ollama
   output channel for troubleshooting.
 
-Use `Diagnose Models` if models are available in Ollama but do not appear in the VS Code model picker. The diagnostics output now also reports whether Open WebUI proxy mode is active and your API key status (masked for security).
 Use `Diagnose Models` if models are available in Ollama but do not appear in the VS Code model picker. The diagnostics output now also reports whether Open WebUI proxy mode is active and your API key status (masked for security).
 
 ## Troubleshooting
@@ -264,12 +158,6 @@ If Ollama models do not appear:
 2. Run `ollama list` (or check Open WebUI's model list) and confirm models are available.
 3. Run `Ollama: Refresh Models` from the Command Palette.
 4. Run `Ollama: Diagnose Models` and check the `Ollama` output channel.
-
-If using Open WebUI proxy mode:
-
-- Ensure your **endpoint** points to Open WebUI (e.g., `http://127.0.0.1:3000`), not directly to Ollama.
-- Verify your **API key** is valid and has permission to access models.
-- Check that Open WebUI has an Ollama backend configured.
 
 If using Open WebUI proxy mode:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ollama",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ollama",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "ollama": "^0.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ollama",
-  "version": "0.0.8",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ollama",
-      "version": "0.0.8",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "ollama": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ollama/ollama-vscode.git"
+    "url": "https://github.com/tpedretti/ollama-vscode-openwebui.git"
   },
   "engines": {
     "vscode": "^1.120.0"
@@ -53,6 +53,18 @@
               "additionalProperties": {
                 "type": "string"
               }
+            },
+            "useOpenWebUIProxy": {
+              "type": "boolean",
+              "title": "Use Open WebUI Proxy",
+              "default": false,
+              "description": "Route requests through Open WebUI's Ollama API Proxy (/ollama/ prefix)."
+            },
+            "openWebUIApiKey": {
+              "type": "string",
+              "title": "Open WebUI API Key",
+              "default": "",
+              "description": "API key for Open WebUI authentication (Bearer token). Required when Use Open WebUI Proxy is enabled."
             }
           }
         }
@@ -74,6 +86,16 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "ollama.useOpenWebUIProxy": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use Open WebUI Ollama API Proxy? When enabled, all requests are routed through Open WebUI's /ollama/ proxy endpoints. Requires an Open WebUI instance running with Ollama backend configured."
+          },
+          "ollama.openWebUIApiKey": {
+            "type": "string",
+            "default": "",
+            "description": "Open WebUI API key (Bearer token). Obtained from Settings > Account in Open WebUI. Required when Use Open WebUI Proxy is enabled."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Ollama",
   "description": "Ollama language model provider for VS Code.",
   "publisher": "Ollama",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "icon": "images/icon.png",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ollama/ollama-vscode.git"
+    "url": "https://github.com/tpedretti/ollama-vscode-openwebui.git"
   },
   "engines": {
     "vscode": "^1.127.0"
@@ -59,6 +59,18 @@
               "additionalProperties": {
                 "type": "string"
               }
+            },
+            "useOpenWebUIProxy": {
+              "type": "boolean",
+              "title": "Use Open WebUI Proxy",
+              "default": false,
+              "description": "Route requests through Open WebUI's Ollama API Proxy (/ollama/ prefix)."
+            },
+            "openWebUIApiKey": {
+              "type": "string",
+              "title": "Open WebUI API Key",
+              "default": "",
+              "description": "API key for Open WebUI authentication (Bearer token). Get it from Open WebUI → Settings → Account → API Keys."
             }
           }
         }
@@ -80,6 +92,16 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "ollama.useOpenWebUIProxy": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use Open WebUI Ollama API Proxy — routes requests through /ollama/ prefix with Bearer auth."
+          },
+          "ollama.openWebUIApiKey": {
+            "type": "string",
+            "default": "",
+            "description": "Open WebUI API key (Bearer token). Get it from Open WebUI → Settings → Account → API Keys."
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,23 @@ async function diagnoseModels(output: vscode.OutputChannel) {
   output.show(true);
   output.appendLine('--- Diagnostics ---');
 
+  const settings = vscode.workspace.getConfiguration('ollama');
+  const endpoint = settings.get<string>('endpoint', defaultOllamaURL) || defaultOllamaURL;
+  const useOpenWebUIProxy = settings.get<boolean>('useOpenWebUIProxy', false);
+  const openWebUIApiKey = settings.get<string>('openWebUIApiKey', '');
+
+  output.appendLine(`Ollama endpoint: ${endpoint}`);
+
+  // Report Open WebUI proxy status
+  if (useOpenWebUIProxy) {
+    const maskedKey = openWebUIApiKey
+      ? openWebUIApiKey.slice(0, 4) + '***'
+      : '(not set — proxy may fail without an API key)';
+    output.appendLine(`Open WebUI Proxy: enabled (key: ${maskedKey})`);
+  } else {
+    output.appendLine(`Open WebUI Proxy: disabled (direct Ollama)`);
+  }
+
   const allVSCodeModels = await vscode.lm.selectChatModels();
   output.appendLine(`VS Code returned ${allVSCodeModels.length} total language model(s).`);
   for (const model of allVSCodeModels) {
@@ -51,12 +68,28 @@ async function diagnoseModels(output: vscode.OutputChannel) {
 
 async function listDirectOllamaModels(output: vscode.OutputChannel): Promise<string[]> {
   const settings = vscode.workspace.getConfiguration('ollama');
-  const endpoint = settings.get<string>('endpoint', defaultOllamaURL) || defaultOllamaURL;
+  let endpoint = settings.get<string>('endpoint', defaultOllamaURL) || defaultOllamaURL;
+  const useOpenWebUIProxy = settings.get<boolean>('useOpenWebUIProxy', false);
+  const openWebUIApiKey = settings.get<string>('openWebUIApiKey', '');
+
+  // If Open WebUI proxy is enabled, prepend /ollama to the base URL
+  if (useOpenWebUIProxy) {
+    endpoint = endpoint.replace(/\/+$/, '') + '/ollama';
+  }
+
   const source = new vscode.CancellationTokenSource();
   const disposables: vscode.Disposable[] = [source];
+  const headers = getConfiguredHeaders(settings);
+
+  // If Open WebUI proxy is enabled, inject the Bearer auth header
+  if (useOpenWebUIProxy && openWebUIApiKey) {
+    headers['Authorization'] = `Bearer ${openWebUIApiKey}`;
+    headers['Content-Type'] = 'application/json';
+  }
+
   const ollama = new Ollama({
     host: endpoint,
-    headers: getConfiguredHeaders(settings),
+    headers,
     fetch: createFetch(source.token, disposables)
   });
   const timer = setTimeout(() => source.cancel(), 5000);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,19 @@ async function diagnoseModels(output: vscode.OutputChannel, provider: OllamaLang
   output.show(true);
   output.appendLine('--- Diagnostics ---');
 
+  // Open WebUI proxy status reporting
+  const settings = vscode.workspace.getConfiguration('ollama');
+  const endpoint = settings.get<string>('endpoint', defaultOllamaURL) || defaultOllamaURL;
+  const useOpenWebUIProxy = settings.get<boolean>('useOpenWebUIProxy', false);
+  const openWebUIApiKey = settings.get<string>('openWebUIApiKey', '');
+  output.appendLine(`Ollama endpoint: ${endpoint}`);
+  if (useOpenWebUIProxy) {
+    const maskedKey = openWebUIApiKey ? openWebUIApiKey.slice(0, 4) + '***' : '(not set — proxy may fail without an API key)';
+    output.appendLine(`Open WebUI Proxy: enabled (key: ${maskedKey})`);
+  } else {
+    output.appendLine('Open WebUI Proxy: disabled (direct Ollama)');
+  }
+
   const allVSCodeModels = await vscode.lm.selectChatModels();
   output.appendLine(`VS Code returned ${allVSCodeModels.length} total language model(s).`);
   for (const model of allVSCodeModels) {
@@ -51,14 +64,35 @@ async function inspectDirectOllamaModels(
 ): Promise<void> {
   const settings = vscode.workspace.getConfiguration('ollama');
   const workspaceEndpoint = settings.get<string>('endpoint', defaultOllamaURL) || defaultOllamaURL;
+
+  // Open WebUI proxy support — read settings for proxy toggle and key
+  const useOpenWebUIProxy = settings.get<boolean>('useOpenWebUIProxy', false);
+  const openWebUIApiKey = settings.get<string>('openWebUIApiKey', '');
+
   const selected = provider.selectDiagnosticsConfiguration({
     url: workspaceEndpoint,
     headers: getConfiguredHeaders(settings)
   });
-  const { url: endpoint, headers } = selected.configuration;
+
+  // Use 'let' so we can rewrite endpoint if proxy is enabled
+  let endpoint = selected.configuration.url;
+  let headers = { ...selected.configuration.headers };
+
   output.appendLine(
     `Direct Ollama API is inspecting ${configurationSourceLabel(selected.source)} at ${endpoint}.`
   );
+
+  // Open WebUI: rewrite URL to prepend /ollama prefix
+  if (useOpenWebUIProxy) {
+    endpoint = endpoint.replace(/\/+$/, '') + '/ollama';
+  }
+
+  // Open WebUI: inject Bearer auth headers when proxy is enabled
+  if (useOpenWebUIProxy && openWebUIApiKey) {
+    headers['Authorization'] = `Bearer ${openWebUIApiKey}`;
+    headers['Content-Type'] = 'application/json';
+  }
+
   const source = new vscode.CancellationTokenSource();
   const disposables: vscode.Disposable[] = [source];
   const ollama = new Ollama(ollamaDiagnosticsClientOptions(

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -27,12 +27,16 @@ interface OllamaProviderConfiguration {
   url: string;
   models: string[];
   headers: Record<string, string>;
+  useOpenWebUIProxy: boolean;
+  openWebUIApiKey: string;
 }
 
 interface OllamaLanguageModel extends vscode.LanguageModelChatInformation {
   model: string;
   url: string;
   headers: Record<string, string>;
+  useOpenWebUIProxy: boolean;
+  openWebUIApiKey: string;
   recommendedReplacement?: string;
 }
 
@@ -117,6 +121,29 @@ class OllamaAPIError extends Error {
   }
 }
 
+// When using Open WebUI proxy mode, prepend /ollama to the base URL so that
+// all Ollama API calls (e.g. /api/tags, /api/chat) resolve as /ollama/api/...
+// which is how Open WebUI's transparent passthrough works.
+function applyOpenWebUIProxyPrefix(url: string, enabled: boolean): string {
+  if (!enabled) return url;
+  // Normalize trailing slashes before appending /ollama
+  const normalized = url.replace(/\/+$/, '');
+  return `${normalized}/ollama`;
+}
+
+// Inject Open WebUI Bearer auth into the headers map when proxy mode is active.
+function applyOpenWebUIAuth(
+  headers: Record<string, string>,
+  enabled: boolean,
+  apiKey: string
+): Record<string, string> {
+  if (!enabled || !apiKey) return headers;
+  const withAuth = { ...headers };
+  withAuth['Authorization'] = `Bearer ${apiKey}`;
+  withAuth['Content-Type'] = 'application/json';
+  return withAuth;
+}
+
 export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProvider<OllamaLanguageModel>, vscode.Disposable {
   private readonly changeEmitter = new vscode.EventEmitter<void>();
   private readonly tokenCounts = new CalibratedTokenEstimator();
@@ -141,9 +168,15 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     const configuration = getConfiguration(options);
     const disposables: vscode.Disposable[] = [];
     const request = createFetch(token, disposables);
+    const proxyUrl = applyOpenWebUIProxyPrefix(configuration.url, configuration.useOpenWebUIProxy);
+    const proxyHeaders = applyOpenWebUIAuth(
+      configuration.headers,
+      configuration.useOpenWebUIProxy,
+      configuration.openWebUIApiKey
+    );
     const ollama = new Ollama({
-      host: configuration.url,
-      headers: configuration.headers,
+      host: proxyUrl,
+      headers: proxyHeaders,
       fetch: request
     });
     const version = await ollama.version()
@@ -160,12 +193,13 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
           : availableModels;
 
         const hydratedModels = await hydrateModels(ollama, models);
+        const proxyLabel = configuration.useOpenWebUIProxy ? ' (via Open WebUI proxy)' : '';
         const versionSuffix = version ? ` with Ollama ${version}` : '';
         const recommendationSuffix = recommendations.length > 0
           ? ` using ${recommendations.length} recommendation(s)`
           : '';
         this.output?.appendLine(
-          `Providing ${models.length} Ollama model(s) from ${configuration.url}${versionSuffix}${recommendationSuffix}.`
+          `Providing ${models.length} Ollama model(s) from ${proxyUrl}${proxyLabel}${versionSuffix}${recommendationSuffix}.`
         );
 
         return hydratedModels.map(({ model, show }) => this.toLanguageModel(
@@ -211,13 +245,19 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     const disposables: vscode.Disposable[] = [];
     const chatFetch = createChatFetch();
     disposables.push(chatFetch);
+    const proxyUrl = applyOpenWebUIProxyPrefix(model.url, model.useOpenWebUIProxy);
+    const proxyHeaders = applyOpenWebUIAuth(
+      model.headers,
+      model.useOpenWebUIProxy,
+      model.openWebUIApiKey
+    );
     const ollama = new Ollama({
-      host: model.url,
-      headers: model.headers,
+      host: proxyUrl,
+      headers: proxyHeaders,
       fetch: createFetch(token, disposables, chatFetch.fetch)
     });
     const tools = toOllamaTools(options.tools);
-    this.output?.appendLine(`Sending chat request to ${model.model} at ${model.url}.`);
+    this.output?.appendLine(`Sending chat request to ${model.model} at ${proxyUrl}.`);
     let requestSucceeded = false;
 
     try {
@@ -386,6 +426,8 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       model: name,
       url: configuration.url,
       headers: configuration.headers,
+      useOpenWebUIProxy: configuration.useOpenWebUIProxy,
+      openWebUIApiKey: configuration.openWebUIApiKey,
       recommendedReplacement: replacement
     };
   }
@@ -511,7 +553,14 @@ function getConfiguration(options?: vscode.PrepareLanguageModelChatModelOptions)
     models: Array.isArray(configuration?.models)
       ? configuration.models.filter((model): model is string => typeof model === 'string' && model.length > 0)
       : [],
-    headers: getConfiguredHeaders(configuration, settings)
+    headers: getConfiguredHeaders(configuration, settings),
+    useOpenWebUIProxy:
+      (typeof configuration?.useOpenWebUIProxy === 'boolean' ? configuration.useOpenWebUIProxy :
+        settings.get<boolean>('useOpenWebUIProxy', false)) || false,
+    openWebUIApiKey:
+      typeof configuration?.openWebUIApiKey === 'string'
+        ? configuration.openWebUIApiKey
+        : settings.get<string>('openWebUIApiKey', '') || ''
   };
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -39,6 +39,8 @@ interface OllamaProviderConfiguration {
   url: string;
   models: string[];
   headers: Record<string, string>;
+  useOpenWebUIProxy: boolean;
+  openWebUIApiKey: string;
 }
 
 interface OllamaLanguageModel extends vscode.LanguageModelChatInformation {
@@ -46,6 +48,8 @@ interface OllamaLanguageModel extends vscode.LanguageModelChatInformation {
   url: string;
   headers: Record<string, string>;
   local: boolean;
+  useOpenWebUIProxy: boolean;
+  openWebUIApiKey: string;
   recommendedReplacement?: string;
 }
 
@@ -133,6 +137,28 @@ class OllamaAPIError extends Error {
   }
 }
 
+// When using Open WebUI proxy mode, prepend /ollama to the base URL so that
+// all Ollama API calls (e.g. /api/tags, /api/chat) resolve as /ollama/api/...
+// which is how Open WebUI's transparent passthrough works.
+function applyOpenWebUIProxyPrefix(url: string, enabled: boolean): string {
+  if (!enabled) return url;
+  const normalized = url.replace(/\/+$/, '');
+  return `${normalized}/ollama`;
+}
+
+// Inject Open WebUI Bearer auth into the headers map when proxy mode is active.
+function applyOpenWebUIAuth(
+  headers: Record<string, string>,
+  enabled: boolean,
+  apiKey: string
+): Record<string, string> {
+  if (!enabled || !apiKey) return headers;
+  const withAuth = { ...headers };
+  withAuth['Authorization'] = `Bearer ${apiKey}`;
+  withAuth['Content-Type'] = 'application/json';
+  return withAuth;
+}
+
 export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProvider<OllamaLanguageModel>, vscode.Disposable {
   private readonly changeEmitter = new vscode.EventEmitter<void>();
   private readonly tokenCounts = new CalibratedTokenEstimator();
@@ -166,9 +192,15 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     this.diagnosticsConfigurations.recordResolved(configuration);
     const disposables: vscode.Disposable[] = [];
     const request = createFetch(token, disposables);
+    const proxyUrl = applyOpenWebUIProxyPrefix(configuration.url, configuration.useOpenWebUIProxy);
+    const proxyHeaders = applyOpenWebUIAuth(
+      configuration.headers,
+      configuration.useOpenWebUIProxy,
+      configuration.openWebUIApiKey
+    );
     const ollama = new Ollama({
-      host: configuration.url,
-      headers: configuration.headers,
+      host: proxyUrl,
+      headers: proxyHeaders,
       fetch: request
     });
     const version = await ollama.version()
@@ -185,12 +217,13 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
           : availableModels;
 
         const hydratedModels = await hydrateModels(ollama, models);
+        const proxyLabel = configuration.useOpenWebUIProxy ? ' (via Open WebUI proxy)' : '';
         const versionSuffix = version ? ` with Ollama ${version}` : '';
         const recommendationSuffix = recommendations.length > 0
           ? ` using ${recommendations.length} recommendation(s)`
           : '';
         this.output?.appendLine(
-          `Providing ${models.length} Ollama model(s) from ${configuration.url}${versionSuffix}${recommendationSuffix}.`
+          `Providing ${models.length} Ollama model(s) from ${proxyUrl}${proxyLabel}${versionSuffix}${recommendationSuffix}.`
         );
 
         return hydratedModels.map(({ model, show }) => this.toLanguageModel(
@@ -236,14 +269,20 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
     const disposables: vscode.Disposable[] = [];
     const chatFetch = createChatFetch();
     disposables.push(chatFetch);
+    const proxyUrl = applyOpenWebUIProxyPrefix(model.url, model.useOpenWebUIProxy);
+    const proxyHeaders = applyOpenWebUIAuth(
+      model.headers,
+      model.useOpenWebUIProxy,
+      model.openWebUIApiKey
+    );
     const ollama = new Ollama({
-      host: model.url,
-      headers: model.headers,
+      host: proxyUrl,
+      headers: proxyHeaders,
       fetch: createFetch(token, disposables, chatFetch.fetch)
     });
     const tools = toOllamaTools(options.tools);
     this.diagnosticsConfigurations.recordUsed(model);
-    this.output?.appendLine(`Sending chat request to ${model.model} at ${model.url}.`);
+    this.output?.appendLine(`Sending chat request to ${model.model} at ${proxyUrl}.`);
     let requestSucceeded = false;
     let machineContextSource: vscode.CancellationTokenSource | undefined;
 
@@ -271,8 +310,8 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
           machineContextSource.cancel();
         }
         const contextOllama = new Ollama({
-          host: model.url,
-          headers: model.headers,
+          host: proxyUrl,
+          headers: proxyHeaders,
           fetch: createFetch(machineContextSource.token, disposables)
         });
         contextLengthCheck = this.checkMachineContextLength(
@@ -520,6 +559,8 @@ export class OllamaLanguageModelProvider implements vscode.LanguageModelChatProv
       url: configuration.url,
       headers: configuration.headers,
       local: !isRemoteModel(model) && !isCloudModel(name),
+      useOpenWebUIProxy: configuration.useOpenWebUIProxy,
+      openWebUIApiKey: configuration.openWebUIApiKey,
       recommendedReplacement: replacement
     };
   }
@@ -673,7 +714,14 @@ function getConfiguration(options?: vscode.PrepareLanguageModelChatModelOptions)
     models: Array.isArray(configuration?.models)
       ? configuration.models.filter((model): model is string => typeof model === 'string' && model.length > 0)
       : [],
-    headers: getConfiguredHeaders(configuration, settings)
+    headers: getConfiguredHeaders(configuration, settings),
+    useOpenWebUIProxy:
+      (typeof configuration?.useOpenWebUIProxy === 'boolean' ? configuration.useOpenWebUIProxy :
+        settings.get<boolean>('useOpenWebUIProxy', false)) || false,
+    openWebUIApiKey:
+      typeof configuration?.openWebUIApiKey === 'string'
+        ? configuration.openWebUIApiKey
+        : settings.get<string>('openWebUIApiKey', '') || ''
   };
 }
 


### PR DESCRIPTION
## Summary

This PR adds first-class support for routing VS Code Chat requests through an **Open WebUI** instance using its [Ollama API Proxy](https://docs.openwebui.com/reference/api-endpoints/#ollama-api-proxy-support).

This branch is synced with upstream v0.0.8 and on top of all recent changes (context-length diagnostics, machine context checking, tool result hardening, system CA trust, VS Code 1.127 requirement).

## What This Adds

### Settings (workspace + provider config via `chatLanguageModels.json`)
- **`ollama.useOpenWebUIProxy`** (boolean, default: `false`) — enable proxy routing
- **`ollama.openWebUIApiKey`** (string, default: `""`) — Bearer token for Open WebUI auth

### How It Works
| | Direct Ollama | Via Open WebUI Proxy |
|---|---|---|
| **List models** | `GET http://localhost:11434/api/tags` | `GET http://localhost:3000/ollama/api/tags` |
| **Chat** | `POST http://localhost:11434/api/chat` | `POST http://localhost:3000/ollama/api/chat` |
| **Auth header** | *(none)* | `Authorization: Bearer <API_KEY>` |

When proxy mode is enabled:
1. The extension automatically prepends `/ollama` to your endpoint URL (e.g., `http://127.0.0.1:3000` becomes `http://127.0.0.1:3000/ollama`)
2. A `Bearer` token is injected into every request
3. **All Ollama API calls go through the proxy** — model discovery, chat requests, context-length diagnostics, and direct model inspection
4. The diagnostics command reports proxy mode status with a masked API key

### Configuration Examples

#### VS Code Settings UI
Search for "Ollama" → enable "Use Open WebUI Proxy" + enter your API key.

#### settings.json
```json
{
  "ollama.endpoint": "http://127.0.0.1:3000",
  "ollama.useOpenWebUIProxy": true,
  "ollama.openWebUIApiKey": "your-api-key-here"
}
```

#### chatLanguageModels.json (per-provider override)
```json
[
  {
    "vendor": "ollama-models",
    "name": "Ollama",
    "url": "http://127.0.0.1:3000",
    "useOpenWebUIProxy": true,
    "openWebUIApiKey": "your-api-key-here",
    "models": ["qwen3.6"]
  }
]
```

## Key Implementation Details

- Proxy helpers (`applyOpenWebUIProxyPrefix`, `applyOpenWebUIAuth`) are **no-ops when disabled** — zero overhead when proxy mode is off
- The machine context length checker also goes through the proxy (avoids bypassing auth/middleware)
- Diagnostics output shows proxy status and masked API key for troubleshooting

## Changes Summary

| File | Change |
|---|---|
| `src/provider.ts` | Proxy interfaces, helper functions, integration into model creation + chat flow + context checking |
| `src/extension.ts` | Proxy status in diagnostics, proxy-aware direct model inspection |
| `package.json` | Two new settings schemas (provider config + workspace) |
| `README.md` | Full Open WebUI proxy documentation section |
| `DEVELOPMENT.md` | Proxy configuration examples |

## Testing

- [x] Direct Ollama mode works unchanged (proxy disabled by default)
- [ ] Test with Open WebUI proxy enabled + valid API key
- [ ] Test with Open WebUI proxy enabled + invalid/missing API key
- [ ] Verify diagnostics output shows correct proxy status
